### PR TITLE
Feature/structured concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,26 @@ jobs:
     environment: default
     strategy:
       matrix:
+        os:
+          - macos-11
+          - macos-12
         xcode:
+          - '12.4'
+          - '12.5.1'
           - '13.2'
           - '13.4'
           - '14.0'
+        exclude:
+          - os: macos-11
+            xcode: '13.2'
+          - os: macos-11
+            xcode: '13.4'
+          - os: macos-11
+            xcode: '14.0'
+          - os: macos-12
+            xcode: '12.4'
+          - os: macos-12
+            xcode: '12.5.1'
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   library:
-    runs-on: macos-11.0
+    runs-on: macos-12
     environment: default
     strategy:
       matrix:
         xcode:
-          - '12.4'
-          - '12.5.1'
           - '13.2'
+          - '13.4'
+          - '14.0'
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             xcode: '12.4'
           - os: macos-12
             xcode: '12.5.1'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   library:
-    runs-on: macos-12
     environment: default
     strategy:
       matrix:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/NetworkService-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/NetworkService-Package.xcscheme
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkService"
+               BuildableName = "NetworkService"
+               BlueprintName = "NetworkService"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelper"
+               BuildableName = "NetworkServiceTestHelper"
+               BlueprintName = "NetworkServiceTestHelper"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceAsyncBetaTests"
+               BuildableName = "NetworkServiceAsyncBetaTests"
+               BlueprintName = "NetworkServiceAsyncBetaTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperAsyncBetaTests"
+               BuildableName = "NetworkServiceTestHelperAsyncBetaTests"
+               BlueprintName = "NetworkServiceTestHelperAsyncBetaTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperTests"
+               BuildableName = "NetworkServiceTestHelperTests"
+               BlueprintName = "NetworkServiceTestHelperTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTests"
+               BuildableName = "NetworkServiceTests"
+               BlueprintName = "NetworkServiceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceAsyncBeta"
+               BuildableName = "NetworkServiceAsyncBeta"
+               BlueprintName = "NetworkServiceAsyncBeta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperAsyncBeta"
+               BuildableName = "NetworkServiceTestHelperAsyncBeta"
+               BlueprintName = "NetworkServiceTestHelperAsyncBeta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceAsyncBetaTests"
+               BuildableName = "NetworkServiceAsyncBetaTests"
+               BlueprintName = "NetworkServiceAsyncBetaTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperAsyncBetaTests"
+               BuildableName = "NetworkServiceTestHelperAsyncBetaTests"
+               BlueprintName = "NetworkServiceTestHelperAsyncBetaTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperTests"
+               BuildableName = "NetworkServiceTestHelperTests"
+               BlueprintName = "NetworkServiceTestHelperTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTests"
+               BuildableName = "NetworkServiceTests"
+               BlueprintName = "NetworkServiceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NetworkService"
+            BuildableName = "NetworkService"
+            BlueprintName = "NetworkService"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/NetworkService.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/NetworkService.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkService"
+               BuildableName = "NetworkService"
+               BlueprintName = "NetworkService"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTests"
+               BuildableName = "NetworkServiceTests"
+               BlueprintName = "NetworkServiceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NetworkService"
+            BuildableName = "NetworkService"
+            BlueprintName = "NetworkService"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/NetworkServiceAsyncBeta.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/NetworkServiceAsyncBeta.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceAsyncBeta"
+               BuildableName = "NetworkServiceAsyncBeta"
+               BlueprintName = "NetworkServiceAsyncBeta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceAsyncBetaTests"
+               BuildableName = "NetworkServiceAsyncBetaTests"
+               BlueprintName = "NetworkServiceAsyncBetaTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NetworkServiceAsyncBeta"
+            BuildableName = "NetworkServiceAsyncBeta"
+            BlueprintName = "NetworkServiceAsyncBeta"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/NetworkServiceTestHelper.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/NetworkServiceTestHelper.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelper"
+               BuildableName = "NetworkServiceTestHelper"
+               BlueprintName = "NetworkServiceTestHelper"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperTests"
+               BuildableName = "NetworkServiceTestHelperTests"
+               BlueprintName = "NetworkServiceTestHelperTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NetworkServiceTestHelper"
+            BuildableName = "NetworkServiceTestHelper"
+            BlueprintName = "NetworkServiceTestHelper"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/NetworkServiceTestHelperAsyncBeta.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/NetworkServiceTestHelperAsyncBeta.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperAsyncBeta"
+               BuildableName = "NetworkServiceTestHelperAsyncBeta"
+               BlueprintName = "NetworkServiceTestHelperAsyncBeta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NetworkServiceTestHelperAsyncBetaTests"
+               BuildableName = "NetworkServiceTestHelperAsyncBetaTests"
+               BlueprintName = "NetworkServiceTestHelperAsyncBetaTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NetworkServiceTestHelperAsyncBeta"
+            BuildableName = "NetworkServiceTestHelperAsyncBeta"
+            BlueprintName = "NetworkServiceTestHelperAsyncBeta"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers.git",
         "state": {
           "branch": null,
-          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
-          "version": "0.5.0"
+          "revision": "aa3e575929f2bcc5bad012bd2575eae716cbcdf7",
+          "version": "0.8.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
-          "version": "0.1.0"
+          "revision": "30314f1ece684dd60679d598a9b89107557b67d9",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,14 @@ let package = Package(
             name: "NetworkServiceTestHelper",
             targets: ["NetworkServiceTestHelper"]
         ),
+        .library(
+            name: "NetworkServiceAsyncBeta",
+            targets: ["NetworkServiceAsyncBeta"]
+        ),
+        .library(
+            name: "NetworkServiceTestHelperAsyncBeta",
+            targets: ["NetworkServiceTestHelperAsyncBeta"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
@@ -37,6 +45,15 @@ let package = Package(
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             ]
         ),
+        .target(name: "NetworkServiceAsyncBeta"),
+        .testTarget(
+            name: "NetworkServiceAsyncBetaTests",
+            dependencies: [
+                "NetworkServiceAsyncBeta",
+                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+            ]
+        ),
         .target(
             name: "NetworkServiceTestHelper",
             dependencies: ["NetworkService", .product(name: "CombineSchedulers", package: "combine-schedulers")]
@@ -45,6 +62,17 @@ let package = Package(
             name: "NetworkServiceTestHelperTests",
             dependencies: [
                 "NetworkServiceTestHelper",
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ]
+        ),
+        .target(
+            name: "NetworkServiceTestHelperAsyncBeta",
+            dependencies: ["NetworkServiceAsyncBeta", .product(name: "CombineSchedulers", package: "combine-schedulers")]
+        ),
+        .testTarget(
+            name: "NetworkServiceTestHelperAsyncBetaTests",
+            dependencies: [
+                "NetworkServiceTestHelperAsyncBeta",
                 .product(name: "CombineSchedulers", package: "combine-schedulers"),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -18,135 +18,134 @@ let package = Package(
 )
 
 #if swift(>=5.5)
-extension Product {
-    static let products: [Product] = [
-        .library(
-            name: "NetworkService",
-            targets: ["NetworkService"]
-        ),
-        .library(
-            name: "NetworkServiceTestHelper",
-            targets: ["NetworkServiceTestHelper"]
-        ),
-        .library(
-            name: "NetworkServiceAsyncBeta",
-            targets: ["NetworkServiceAsyncBeta"]
-        ),
-        .library(
-            name: "NetworkServiceTestHelperAsyncBeta",
-            targets: ["NetworkServiceTestHelperAsyncBeta"]
-        ),
-    ]
-}
+    extension Product {
+        static let products: [Product] = [
+            .library(
+                name: "NetworkService",
+                targets: ["NetworkService"]
+            ),
+            .library(
+                name: "NetworkServiceTestHelper",
+                targets: ["NetworkServiceTestHelper"]
+            ),
+            .library(
+                name: "NetworkServiceAsyncBeta",
+                targets: ["NetworkServiceAsyncBeta"]
+            ),
+            .library(
+                name: "NetworkServiceTestHelperAsyncBeta",
+                targets: ["NetworkServiceTestHelperAsyncBeta"]
+            ),
+        ]
+    }
 
-extension Target {
-    static let targets: [Target] = [
-        .target(
-            name: "NetworkService",
-            dependencies: []
-        ),
-        .testTarget(
-            name: "NetworkServiceTests",
-            dependencies: [
-                "NetworkService",
-                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
-                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
-            ]
-        ),
-        .target(
-            name: "NetworkServiceAsyncBeta",
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
-            ]
-        ),
-        .testTarget(
-            name: "NetworkServiceAsyncBetaTests",
-            dependencies: [
-                "NetworkServiceAsyncBeta",
-                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
-                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
-            ]
-        ),
-        .target(
-            name: "NetworkServiceTestHelper",
-            dependencies: [
-                "NetworkService",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
-            ]
-        ),
-        .testTarget(
-            name: "NetworkServiceTestHelperTests",
-            dependencies: [
-                "NetworkServiceTestHelper",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ]
-        ),
-        .target(
-            name: "NetworkServiceTestHelperAsyncBeta",
-            dependencies: [
-                "NetworkServiceAsyncBeta",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ]
-        ),
-        .testTarget(
-            name: "NetworkServiceTestHelperAsyncBetaTests",
-            dependencies: [
-                "NetworkServiceTestHelperAsyncBeta",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ]
-        ),
-    ]
-}
-
+    extension Target {
+        static let targets: [Target] = [
+            .target(
+                name: "NetworkService",
+                dependencies: []
+            ),
+            .testTarget(
+                name: "NetworkServiceTests",
+                dependencies: [
+                    "NetworkService",
+                    .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                    .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+                ]
+            ),
+            .target(
+                name: "NetworkServiceAsyncBeta",
+                swiftSettings: [
+                    .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
+                ]
+            ),
+            .testTarget(
+                name: "NetworkServiceAsyncBetaTests",
+                dependencies: [
+                    "NetworkServiceAsyncBeta",
+                    .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                    .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+                ]
+            ),
+            .target(
+                name: "NetworkServiceTestHelper",
+                dependencies: [
+                    "NetworkService",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ],
+                swiftSettings: [
+                    .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
+                ]
+            ),
+            .testTarget(
+                name: "NetworkServiceTestHelperTests",
+                dependencies: [
+                    "NetworkServiceTestHelper",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ]
+            ),
+            .target(
+                name: "NetworkServiceTestHelperAsyncBeta",
+                dependencies: [
+                    "NetworkServiceAsyncBeta",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ]
+            ),
+            .testTarget(
+                name: "NetworkServiceTestHelperAsyncBetaTests",
+                dependencies: [
+                    "NetworkServiceTestHelperAsyncBeta",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ]
+            ),
+        ]
+    }
 
 #else
-extension Product {
-    static let products: [Product] = [
-        .library(
-            name: "NetworkService",
-            targets: ["NetworkService"]
-        ),
-        .library(
-            name: "NetworkServiceTestHelper",
-            targets: ["NetworkServiceTestHelper"]
-        ),
-    ]
-}
+    extension Product {
+        static let products: [Product] = [
+            .library(
+                name: "NetworkService",
+                targets: ["NetworkService"]
+            ),
+            .library(
+                name: "NetworkServiceTestHelper",
+                targets: ["NetworkServiceTestHelper"]
+            ),
+        ]
+    }
 
-extension Target {
-    static let targets: [Target] = [
-        .target(
-            name: "NetworkService",
-            dependencies: []
-        ),
-        .testTarget(
-            name: "NetworkServiceTests",
-            dependencies: [
-                "NetworkService",
-                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
-                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
-            ]
-        ),
-        .target(
-            name: "NetworkServiceTestHelper",
-            dependencies: [
-                "NetworkService",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
-            ]
-        ),
-        .testTarget(
-            name: "NetworkServiceTestHelperTests",
-            dependencies: [
-                "NetworkServiceTestHelper",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ]
-        ),
-    ]
-}
+    extension Target {
+        static let targets: [Target] = [
+            .target(
+                name: "NetworkService",
+                dependencies: []
+            ),
+            .testTarget(
+                name: "NetworkServiceTests",
+                dependencies: [
+                    "NetworkService",
+                    .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                    .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+                ]
+            ),
+            .target(
+                name: "NetworkServiceTestHelper",
+                dependencies: [
+                    "NetworkService",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ],
+                swiftSettings: [
+                    .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
+                ]
+            ),
+            .testTarget(
+                name: "NetworkServiceTestHelperTests",
+                dependencies: [
+                    "NetworkServiceTestHelper",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ]
+            ),
+        ]
+    }
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -156,7 +156,7 @@ let package = Package(
             .package(
                 name: "combine-schedulers",
                 url: "https://github.com/pointfreeco/combine-schedulers.git",
-                exact: .upToNextMinor(from: "0.5.3")
+                .upToNextMinor(from: "0.5.3")
             ),
         ]
     }

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,12 @@ let package = Package(
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             ]
         ),
-        .target(name: "NetworkServiceAsyncBeta"),
+        .target(
+            name: "NetworkServiceAsyncBeta",
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-warn-concurrency"])
+            ]
+        ),
         .testTarget(
             name: "NetworkServiceAsyncBetaTests",
             dependencies: [
@@ -56,7 +61,13 @@ let package = Package(
         ),
         .target(
             name: "NetworkServiceTestHelper",
-            dependencies: ["NetworkService", .product(name: "CombineSchedulers", package: "combine-schedulers")]
+            dependencies: [
+                "NetworkService",
+                .product(name: "CombineSchedulers", package: "combine-schedulers")
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-warn-concurrency"])
+            ]
         ),
         .testTarget(
             name: "NetworkServiceTestHelperTests",

--- a/Package.swift
+++ b/Package.swift
@@ -134,9 +134,6 @@ let package = Package(
                 dependencies: [
                     "NetworkService",
                     .product(name: "CombineSchedulers", package: "combine-schedulers"),
-                ],
-                swiftSettings: [
-                    .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
                 ]
             ),
             .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -6,14 +6,7 @@ let package = Package(
     name: "NetworkService",
     platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: Product.products,
-    dependencies: [
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-        .package(
-            name: "combine-schedulers",
-            url: "https://github.com/pointfreeco/combine-schedulers.git",
-            .upToNextMajor(from: "0.5.0")
-        ),
-    ],
+    dependencies: Package.Dependency.dependencies,
     targets: Target.targets
 )
 
@@ -101,6 +94,17 @@ let package = Package(
         ]
     }
 
+    extension Package.Dependency {
+        static let dependencies: [Package.Dependency] = [
+            .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+            .package(
+                name: "combine-schedulers",
+                url: "https://github.com/pointfreeco/combine-schedulers.git",
+                .upToNextMajor(from: "0.6.0")
+            ),
+        ]
+    }
+
 #else
     extension Product {
         static let products: [Product] = [
@@ -142,6 +146,17 @@ let package = Package(
                     "NetworkServiceTestHelper",
                     .product(name: "CombineSchedulers", package: "combine-schedulers"),
                 ]
+            ),
+        ]
+    }
+
+    extension Package.Dependency {
+        static let dependencies: [Package.Dependency] = [
+            .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+            .package(
+                name: "combine-schedulers",
+                url: "https://github.com/pointfreeco/combine-schedulers.git",
+                exact: .upToNextMinor(from: "0.5.3")
             ),
         ]
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,25 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "NetworkService",
     platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
-    products: [
+    products: Product.products,
+    dependencies: [
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(
+            name: "combine-schedulers",
+            url: "https://github.com/pointfreeco/combine-schedulers.git",
+            .upToNextMajor(from: "0.5.0")
+        ),
+    ],
+    targets: Target.targets
+)
+
+#if swift(>=5.5)
+extension Product {
+    static let products: [Product] = [
         .library(
             name: "NetworkService",
             targets: ["NetworkService"]
@@ -23,16 +36,11 @@ let package = Package(
             name: "NetworkServiceTestHelperAsyncBeta",
             targets: ["NetworkServiceTestHelperAsyncBeta"]
         ),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-        .package(
-            name: "combine-schedulers",
-            url: "https://github.com/pointfreeco/combine-schedulers.git",
-            .upToNextMajor(from: "0.5.0")
-        ),
-    ],
-    targets: [
+    ]
+}
+
+extension Target {
+    static let targets: [Target] = [
         .target(
             name: "NetworkService",
             dependencies: []
@@ -91,4 +99,54 @@ let package = Package(
             ]
         ),
     ]
-)
+}
+
+
+#else
+extension Product {
+    static let products: [Product] = [
+        .library(
+            name: "NetworkService",
+            targets: ["NetworkService"]
+        ),
+        .library(
+            name: "NetworkServiceTestHelper",
+            targets: ["NetworkServiceTestHelper"]
+        ),
+    ]
+}
+
+extension Target {
+    static let targets: [Target] = [
+        .target(
+            name: "NetworkService",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "NetworkServiceTests",
+            dependencies: [
+                "NetworkService",
+                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+            ]
+        ),
+        .target(
+            name: "NetworkServiceTestHelper",
+            dependencies: [
+                "NetworkService",
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
+            ]
+        ),
+        .testTarget(
+            name: "NetworkServiceTestHelperTests",
+            dependencies: [
+                "NetworkServiceTestHelper",
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ]
+        ),
+    ]
+}
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .target(
             name: "NetworkServiceAsyncBeta",
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-concurrency"])
+                .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
             ]
         ),
         .testTarget(
@@ -63,10 +63,10 @@ let package = Package(
             name: "NetworkServiceTestHelper",
             dependencies: [
                 "NetworkService",
-                .product(name: "CombineSchedulers", package: "combine-schedulers")
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
             ],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-concurrency"])
+                .unsafeFlags(["-Xfrontend", "-warn-concurrency"]),
             ]
         ),
         .testTarget(
@@ -78,7 +78,10 @@ let package = Package(
         ),
         .target(
             name: "NetworkServiceTestHelperAsyncBeta",
-            dependencies: ["NetworkServiceAsyncBeta", .product(name: "CombineSchedulers", package: "combine-schedulers")]
+            dependencies: [
+                "NetworkServiceAsyncBeta",
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ]
         ),
         .testTarget(
             name: "NetworkServiceTestHelperAsyncBetaTests",

--- a/Sources/NetworkServiceAsyncBeta/HTTPURLResponse+StatusCode.swift
+++ b/Sources/NetworkServiceAsyncBeta/HTTPURLResponse+StatusCode.swift
@@ -1,0 +1,134 @@
+// HTTPURLResponse+StatusCode.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+
+extension HTTPURLResponse {
+    public typealias StatusCode = Int
+
+    /// Naive check if the status code is within the informational range
+    public var isInformational: Bool { StatusCode.informational.contains(statusCode) }
+
+    /// Naive check if the status code is within the success range
+    public var isSuccessful: Bool { StatusCode.successful.contains(statusCode) }
+
+    /// Naive check if the status code is within the redirect range
+    public var isRedirect: Bool { StatusCode.redirect.contains(statusCode) }
+
+    /// Naive check if the status code is within the client error range
+    public var isClientError: Bool { StatusCode.clientError.contains(statusCode) }
+
+    /// Naive check if the status code is within the server error range
+    public var isServerError: Bool { StatusCode.clientError.contains(statusCode) }
+}
+
+extension HTTPURLResponse.StatusCode {
+    // MARK: Informational
+
+    /// Range of status codes for informational response - RFC 2616, RFC 7231
+    public static let informational = 100 ... 199
+
+    // MARK: Unused Informational
+
+    static let `continue` = 100
+    static let switchingProtocol = 101
+    static let processing = 102
+    static let earlyHints = 103
+
+    // MARK: Successful
+
+    /// Range of status codes for successful response - RFC 2616, RFC 7231
+    public static let successful = 200 ... 299
+    // swiftlint:disable:next identifier_name
+    public static let ok = 200
+    public static let created = 201
+
+    // MARK: Unused Successful
+
+    static let accepted = 202
+    static let nonAutoritativeInformation = 203
+    static let noContent = 204
+    static let resetContent = 205
+    static let partialContent = 206
+    static let multiStatus = 207
+    static let alreadyReported = 208
+    static let imUsed = 226
+
+    // MARK: Redirect
+
+    /// Range of status codes for redirect response - RFC 2616, RFC 7231
+    public static let redirect = 300 ... 399
+
+    // MARK: Unused Redirect
+
+    static let multipleChoice = 300
+    static let movedPermanently = 301
+    static let found = 302
+    static let seeOther = 303
+    static let notModified = 304
+    static let useProxy = 305
+    static let unused = 306
+    static let temporaryRedirect = 307
+    static let permanentRedirect = 308
+
+    // MARK: Client Error
+
+    /// Range of status codes for client error response - RFC 2616, RFC 7231
+    public static let clientError = 400 ... 499
+    public static let badRequest = 400
+    public static let forbidden = 403
+
+    // MARK: Unused Client Error
+
+    static let unauthorized = 401
+    static let paymentRequired = 402
+    static let notFound = 404
+    static let methodNotAllowed = 405
+    static let notAcceptable = 406
+    static let proxyAuthenticationRequired = 407
+    static let requestTimeout = 408
+    static let conflict = 409
+    static let gone = 410
+    static let lengthRequired = 411
+    static let preconditionFailed = 412
+    static let payloadTooLarge = 413
+    static let uriTooLong = 414
+    static let unsupportedMediaType = 415
+    static let rangeNotSatisfiable = 416
+    static let expectationFailed = 417
+    static let imATeapot = 418
+    static let misdirectedRequest = 421
+    static let unprocessableEntity = 422
+    static let locked = 423
+    static let failedDependency = 424
+    static let tooEarly = 425
+    static let upgradeRequired = 426
+    static let preconditionRequired = 428
+    static let tooManyRequests = 429
+    static let requestHeaderFieldsTooLarge = 431
+    static let unavailableForLegalReasons = 451
+
+    // MARK: Server Error
+
+    /// Range of status codes for server error response - RFC 2616, RFC 7231
+    public static let serverError = 500 ... 599
+
+    // MARK: Unused Server Error
+
+    static let internalServerError = 500
+    static let notImplemented = 501
+    static let badGateway = 502
+    static let serviceUnavailable = 503
+    static let gatewayTimeout = 504
+    static let httpVersionNotSupported = 505
+    static let variantAlsoNegotiates = 506
+    static let insufficientStorage = 507
+    static let loopDetected = 508
+    static let notExtended = 510
+    static let networkAuthenticationRequired = 511
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkService.swift
@@ -23,5 +23,6 @@ public final class NetworkService {
 }
 
 // MARK: NetworkService+NetworkServiceClient
+
 @available(swift 5.5)
 extension NetworkService: NetworkServiceClient {}

--- a/Sources/NetworkServiceAsyncBeta/NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkService.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Provides methods for making network requests and processing the resulting responses
 public final class NetworkService {
     /// `NetworkService`'s error domain
-    public enum Failure: Error, Hashable {
+    public enum Failure: Error, Hashable, Sendable {
         case urlResponse(URLResponse)
         case httpResponse(HTTPURLResponse)
         case urlError(URLError)

--- a/Sources/NetworkServiceAsyncBeta/NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkService.swift
@@ -23,5 +23,5 @@ public final class NetworkService {
 }
 
 // MARK: NetworkService+NetworkServiceClient
-
+@available(swift 5.5)
 extension NetworkService: NetworkServiceClient {}

--- a/Sources/NetworkServiceAsyncBeta/NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkService.swift
@@ -1,0 +1,27 @@
+// NetworkService.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+/// Provides methods for making network requests and processing the resulting responses
+public final class NetworkService {
+    /// `NetworkService`'s error domain
+    public enum Failure: Error, Hashable {
+        case urlResponse(URLResponse)
+        case httpResponse(HTTPURLResponse)
+        case urlError(URLError)
+        case unknown(NSError)
+    }
+
+    public init() {}
+}
+
+// MARK: NetworkService+NetworkServiceClient
+
+extension NetworkService: NetworkServiceClient {}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
@@ -19,7 +19,7 @@ extension NetworkServiceClient {
         _ url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        let request = URLRequest.service(url: url, headers: headers, method: .DELETE)
+        let request = URLRequest.build(url: url, headers: headers, method: .DELETE)
         return await start(request)
     }
 }

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
@@ -6,7 +6,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-import Combine
 import Foundation
 
 extension NetworkServiceClient {
@@ -20,12 +19,15 @@ extension NetworkServiceClient {
         _ url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        var request = URLRequest(url: url)
-        request.method = .DELETE
-        headers.forEach { request.addValue($0) }
+        let request = URLRequest.service(url: url, headers: headers, method: .DELETE)
         return await start(request)
     }
+}
 
+#if canImport(Combine)
+import Combine
+
+extension NetworkServiceClient {
     /// Send a delete request to a `URL`
     /// - Parameters:
     ///   - url: The destination for the request
@@ -37,21 +39,22 @@ extension NetworkServiceClient {
         headers: [HTTPHeader] = [],
         decoder: Decoder
     ) async -> Result<ResponseBody, Failure>
-        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
     {
         await delete(url, headers: headers)
             .decode(with: decoder)
             .mapToNetworkError()
     }
-
+    
     /// Send a delete request to a `URL`
     /// - Parameters:
     ///     - url: The destination for the request
     ///     - headers: HTTP headers for the request
     /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
     public func delete<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
-        where ResponseBody: TopLevelDecodable
+    where ResponseBody: TopLevelDecodable
     {
         await delete(url, headers: headers, decoder: ResponseBody.decoder)
     }
 }
+#endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
@@ -25,36 +25,36 @@ extension NetworkServiceClient {
 }
 
 #if canImport(Combine)
-import Combine
+    import Combine
 
-extension NetworkServiceClient {
-    /// Send a delete request to a `URL`
-    /// - Parameters:
-    ///   - url: The destination for the request
-    ///   - headers: HTTP headers for the request
-    ///   - decoder: `TopLevelDecoder` for decoding the response body
-    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
-    public func delete<ResponseBody, Decoder>(
-        _ url: URL,
-        headers: [HTTPHeader] = [],
-        decoder: Decoder
-    ) async -> Result<ResponseBody, Failure>
-    where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
-    {
-        await delete(url, headers: headers)
-            .decode(with: decoder)
-            .mapToNetworkError()
+    extension NetworkServiceClient {
+        /// Send a delete request to a `URL`
+        /// - Parameters:
+        ///   - url: The destination for the request
+        ///   - headers: HTTP headers for the request
+        ///   - decoder: `TopLevelDecoder` for decoding the response body
+        /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+        public func delete<ResponseBody, Decoder>(
+            _ url: URL,
+            headers: [HTTPHeader] = [],
+            decoder: Decoder
+        ) async -> Result<ResponseBody, Failure>
+            where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+        {
+            await delete(url, headers: headers)
+                .decode(with: decoder)
+                .mapToNetworkError()
+        }
+
+        /// Send a delete request to a `URL`
+        /// - Parameters:
+        ///     - url: The destination for the request
+        ///     - headers: HTTP headers for the request
+        /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+        public func delete<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
+            where ResponseBody: TopLevelDecodable
+        {
+            await delete(url, headers: headers, decoder: ResponseBody.decoder)
+        }
     }
-    
-    /// Send a delete request to a `URL`
-    /// - Parameters:
-    ///     - url: The destination for the request
-    ///     - headers: HTTP headers for the request
-    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
-    public func delete<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
-    where ResponseBody: TopLevelDecodable
-    {
-        await delete(url, headers: headers, decoder: ResponseBody.decoder)
-    }
-}
 #endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Delete.swift
@@ -1,0 +1,57 @@
+// NetworkServiceClient+Delete.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+extension NetworkServiceClient {
+    // MARK: DELETE
+
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func delete(
+        _ url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<Data, Failure> {
+        var request = URLRequest(url: url)
+        request.method = .DELETE
+        headers.forEach { request.addValue($0) }
+        return await start(request)
+    }
+
+    /// Send a delete request to a `URL`
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder: `TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func delete<ResponseBody, Decoder>(
+        _ url: URL,
+        headers: [HTTPHeader] = [],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    {
+        await delete(url, headers: headers)
+            .decode(with: decoder)
+            .mapToNetworkError()
+    }
+
+    /// Send a delete request to a `URL`
+    /// - Parameters:
+    ///     - url: The destination for the request
+    ///     - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    public func delete<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+    {
+        await delete(url, headers: headers, decoder: ResponseBody.decoder)
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
@@ -6,7 +6,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-import Combine
 import Foundation
 
 extension NetworkServiceClient {
@@ -20,12 +19,17 @@ extension NetworkServiceClient {
         _ url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        var request = URLRequest(url: url)
-        request.method = .GET
-        headers.forEach { request.addValue($0) }
+        let request = URLRequest.service(url: url, headers: headers, method: .GET)
         return await start(request)
     }
 
+    
+    
+    
+}
+#if canImport(Combine)
+import Combine
+extension NetworkServiceClient {
     /// Send a get request to a `URL`
     /// - Parameters:
     ///   - url: The destination for the request
@@ -55,3 +59,4 @@ extension NetworkServiceClient {
         await get(url, headers: headers, decoder: ResponseBody.decoder)
     }
 }
+#endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
@@ -1,0 +1,57 @@
+// NetworkServiceClient+Get.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+extension NetworkServiceClient {
+    // MARK: GET
+
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func get(
+        _ url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<Data, Failure> {
+        var request = URLRequest(url: url)
+        request.method = .GET
+        headers.forEach { request.addValue($0) }
+        return await start(request)
+    }
+
+    /// Send a get request to a `URL`
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func get<ResponseBody, Decoder>(
+        _ url: URL,
+        headers: [HTTPHeader] = [],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    {
+        await get(url, headers: headers)
+            .decode(with: decoder)
+            .mapToNetworkError()
+    }
+
+    /// Send a get request to a `URL`
+    /// - Parameters:
+    ///     - url: The destination for the request
+    ///     - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    public func get<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+    {
+        await get(url, headers: headers, decoder: ResponseBody.decoder)
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
@@ -19,7 +19,7 @@ extension NetworkServiceClient {
         _ url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        let request = URLRequest.service(url: url, headers: headers, method: .GET)
+        let request = URLRequest.build(url: url, headers: headers, method: .GET)
         return await start(request)
     }
 }

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Get.swift
@@ -22,41 +22,38 @@ extension NetworkServiceClient {
         let request = URLRequest.service(url: url, headers: headers, method: .GET)
         return await start(request)
     }
-
-    
-    
-    
 }
+
 #if canImport(Combine)
-import Combine
-extension NetworkServiceClient {
-    /// Send a get request to a `URL`
-    /// - Parameters:
-    ///   - url: The destination for the request
-    ///   - headers: HTTP headers for the request
-    ///   - decoder:`TopLevelDecoder` for decoding the response body
-    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
-    public func get<ResponseBody, Decoder>(
-        _ url: URL,
-        headers: [HTTPHeader] = [],
-        decoder: Decoder
-    ) async -> Result<ResponseBody, Failure>
-        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
-    {
-        await get(url, headers: headers)
-            .decode(with: decoder)
-            .mapToNetworkError()
-    }
+    import Combine
+    extension NetworkServiceClient {
+        /// Send a get request to a `URL`
+        /// - Parameters:
+        ///   - url: The destination for the request
+        ///   - headers: HTTP headers for the request
+        ///   - decoder:`TopLevelDecoder` for decoding the response body
+        /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+        public func get<ResponseBody, Decoder>(
+            _ url: URL,
+            headers: [HTTPHeader] = [],
+            decoder: Decoder
+        ) async -> Result<ResponseBody, Failure>
+            where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+        {
+            await get(url, headers: headers)
+                .decode(with: decoder)
+                .mapToNetworkError()
+        }
 
-    /// Send a get request to a `URL`
-    /// - Parameters:
-    ///     - url: The destination for the request
-    ///     - headers: HTTP headers for the request
-    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
-    public func get<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
-        where ResponseBody: TopLevelDecodable
-    {
-        await get(url, headers: headers, decoder: ResponseBody.decoder)
+        /// Send a get request to a `URL`
+        /// - Parameters:
+        ///     - url: The destination for the request
+        ///     - headers: HTTP headers for the request
+        /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+        public func get<ResponseBody>(_ url: URL, headers: [HTTPHeader] = []) async -> Result<ResponseBody, Failure>
+            where ResponseBody: TopLevelDecodable
+        {
+            await get(url, headers: headers, decoder: ResponseBody.decoder)
+        }
     }
-}
 #endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+GetSession.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+GetSession.swift
@@ -1,0 +1,16 @@
+// NetworkServiceClient+GetSession.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+
+extension NetworkServiceClient {
+    /// Default implementation of `getSession` that returns the `shared` instance
+    public func getSession() -> URLSession {
+        URLSession.shared
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
@@ -22,10 +22,7 @@ extension NetworkServiceClient {
         to url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        var request = URLRequest(url: url)
-        request.httpBody = body
-        request.method = .POST
-        headers.forEach { request.addValue($0) }
+        let request = URLRequest.service(url: url, body: body, headers: headers, method: .POST)
         return await start(request)
     }
 
@@ -161,3 +158,9 @@ extension NetworkServiceClient {
         await post(body, to: url, headers: headers, encoder: RequestBody.encoder, decoder: ResponseBody.decoder)
     }
 }
+
+#if canImport(Combine)
+extension NetworkServiceClient {
+    
+}
+#endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
@@ -22,7 +22,7 @@ extension NetworkServiceClient {
         to url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        let request = URLRequest.service(url: url, body: body, headers: headers, method: .POST)
+        let request = URLRequest.build(url: url, body: body, headers: headers, method: .POST)
         return await start(request)
     }
 

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
@@ -1,0 +1,163 @@
+// NetworkServiceClient+Post.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+extension NetworkServiceClient {
+    // MARK: POST
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func post(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<Data, Failure> {
+        var request = URLRequest(url: url)
+        request.httpBody = body
+        request.method = .POST
+        headers.forEach { request.addValue($0) }
+        return await start(request)
+    }
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Encodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder: `TopLevelEncoder` for encoding the request body
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func post<RequestBody, Encoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader],
+        encoder: Encoder
+    ) async -> Result<Data, Failure>
+        where RequestBody: Encodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data
+    {
+        do {
+            let body = try encoder.encode(body)
+            return await post(body, to: url, headers: headers)
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+    }
+
+    /// - Parameters:
+    ///   - body: The body of the request as `TopLevelEnodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func post<RequestBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+        where RequestBody: TopLevelEncodable
+    {
+        do {
+            let body = try RequestBody.encoder.encode(body)
+            return await post(body, to: url, headers: headers)
+        } catch let urlError as URLError {
+            return .failure(Failure.urlError(urlError))
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+    }
+
+    /// Send a post request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func post<ResponseBody, Decoder>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader] = [],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    {
+        var request = URLRequest(url: url)
+        request.httpBody = body
+        request.method = .POST
+        headers.forEach { request.addValue($0) }
+        return await start(request, with: decoder)
+    }
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    public func post<ResponseBody>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+    {
+        await post(body, to: url, headers: headers, decoder: ResponseBody.decoder)
+    }
+
+    /// Send a post request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `Encodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder:`TopLevelEncoder` for encoding the request body
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func post<RequestBody, ResponseBody, Encoder, Decoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader] = [],
+        encoder: Encoder,
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: Encodable,
+        ResponseBody: Decodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data,
+        Decoder: TopLevelDecoder,
+        Decoder.Input == Data
+    {
+        do {
+            let body = try encoder.encode(body)
+            return await post(body, to: url, headers: headers, decoder: decoder)
+        } catch let urlError as URLError {
+            return .failure(Failure.urlError(urlError))
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+    }
+
+    /// Send a post request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `TopLevelEnodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    public func post<RequestBody, ResponseBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: TopLevelEncodable,
+        ResponseBody: TopLevelDecodable
+    {
+        await post(body, to: url, headers: headers, encoder: RequestBody.encoder, decoder: ResponseBody.decoder)
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Post.swift
@@ -160,7 +160,5 @@ extension NetworkServiceClient {
 }
 
 #if canImport(Combine)
-extension NetworkServiceClient {
-    
-}
+    extension NetworkServiceClient {}
 #endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
@@ -22,10 +22,7 @@ extension NetworkServiceClient {
         to url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        var request = URLRequest(url: url)
-        request.httpBody = body
-        request.method = .PUT
-        headers.forEach { request.addValue($0) }
+        let request = URLRequest.service(url: url, body: body, headers: headers, method: .PUT)
         return await start(request)
     }
 
@@ -161,3 +158,9 @@ extension NetworkServiceClient {
         await put(body, to: url, headers: headers, encoder: RequestBody.encoder, decoder: ResponseBody.decoder)
     }
 }
+
+#if canImport(Combine)
+extension NetworkServiceClient {
+    
+}
+#endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
@@ -1,0 +1,163 @@
+// NetworkServiceClient+Put.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+extension NetworkServiceClient {
+    // MARK: PUT
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func put(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<Data, Failure> {
+        var request = URLRequest(url: url)
+        request.httpBody = body
+        request.method = .PUT
+        headers.forEach { request.addValue($0) }
+        return await start(request)
+    }
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Encodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder: `TopLevelEncoder` for encoding the request body
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func put<RequestBody, Encoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader],
+        encoder: Encoder
+    ) async -> Result<Data, Failure>
+        where RequestBody: Encodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data
+    {
+        do {
+            let body = try encoder.encode(body)
+            return await put(body, to: url, headers: headers)
+        } catch let urlError as URLError {
+            return .failure(Failure.urlError(urlError))
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+    }
+
+    /// - Parameters:
+    ///   - body: The body of the request as `TopLevelEncodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    public func put<RequestBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+        where RequestBody: TopLevelEncodable
+    {
+        do {
+            let body = try RequestBody.encoder.encode(body)
+            return await put(body, to: url, headers: headers)
+        } catch let urlError as URLError {
+            return .failure(Failure.urlError(urlError))
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+    }
+
+    /// Send a put request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func put<ResponseBody, Decoder>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader] = [],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    {
+        await put(body, to: url, headers: headers)
+            .decode(with: decoder)
+            .mapToNetworkError()
+    }
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    public func put<ResponseBody>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+    {
+        await put(body, to: url, headers: headers, decoder: ResponseBody.decoder)
+    }
+
+    /// Send a put request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `Encodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder:`TopLevelEncoder` for encoding the request body
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func put<RequestBody, ResponseBody, Encoder, Decoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader] = [],
+        encoder: Encoder,
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: Encodable,
+        ResponseBody: Decodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data,
+        Decoder: TopLevelDecoder,
+        Decoder.Input == Data
+    {
+        do {
+            let body = try encoder.encode(body)
+            return await put(body, to: url, headers: headers, decoder: decoder)
+        } catch let urlError as URLError {
+            return .failure(Failure.urlError(urlError))
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+    }
+
+    /// Send a put request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `Encodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func put<RequestBody, ResponseBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader] = []
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: TopLevelEncodable,
+        ResponseBody: TopLevelDecodable
+    {
+        await put(body, to: url, headers: headers, encoder: RequestBody.encoder, decoder: ResponseBody.decoder)
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
@@ -22,7 +22,7 @@ extension NetworkServiceClient {
         to url: URL,
         headers: [HTTPHeader] = []
     ) async -> Result<Data, Failure> {
-        let request = URLRequest.service(url: url, body: body, headers: headers, method: .PUT)
+        let request = URLRequest.build(url: url, body: body, headers: headers, method: .PUT)
         return await start(request)
     }
 

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Put.swift
@@ -160,7 +160,5 @@ extension NetworkServiceClient {
 }
 
 #if canImport(Combine)
-extension NetworkServiceClient {
-    
-}
+    extension NetworkServiceClient {}
 #endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
@@ -75,7 +75,7 @@ extension NetworkServiceClient {
                             }
                             continuation.resume(returning: (data, urlResponse))
                         })
-                        
+
                         if shouldCancel {
                             task?.cancel()
                         } else {

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
@@ -1,0 +1,89 @@
+// NetworkServiceClient+Start.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+extension NetworkServiceClient {
+    // MARK: URLRequest
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func start<ResponseBody, Decoder>(
+        _ request: URLRequest,
+        with decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    {
+        await start(request)
+            .decode(with: decoder)
+            .mapToNetworkError()
+    }
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func start<ResponseBody>(_ request: URLRequest) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+    {
+        await start(request, with: ResponseBody.decoder)
+    }
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with output as `Data` and `NetworkService`'s error domain for failure
+    public func start(_ request: URLRequest) async -> Result<Data, Failure> {
+        let result: Result<(Data, URLResponse), Error>
+        do {
+            let response: (Data, URLResponse) = try await response(request)
+            result = .success(response)
+        } catch {
+            result = .failure(error)
+        }
+        return result
+            .httpMap()
+            .mapToNetworkError()
+    }
+
+    private func response(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        let session = getSession()
+        if #available(iOS 15, watchOS 8, macOS 12, macCatalyst 15, tvOS 15, *) {
+            return try await session.data(for: request)
+        } else {
+            var task: URLSessionDataTask?
+            var shouldCancel: Bool = false
+            let onCancel = {
+                if let task = task {
+                    task.cancel()
+                } else {
+                    shouldCancel = true
+                }
+            }
+            return try await withTaskCancellationHandler(
+                handler: { onCancel() },
+                operation: {
+                    try await withCheckedThrowingContinuation { continuation in
+                        task = session.dataTask(with: request, completionHandler: { _data, _urlResponse, _error in
+                            guard let data = _data, let urlResponse = _urlResponse else {
+                                return continuation.resume(throwing: _error ?? URLError(.badServerResponse))
+                            }
+                            continuation.resume(returning: (data, urlResponse))
+                        })
+                        
+                        if shouldCancel {
+                            task?.cancel()
+                        } else {
+                            task?.resume()
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
@@ -10,7 +10,6 @@ import Combine
 import Foundation
 
 extension NetworkServiceClient {
-
     /// Start a `URLRequest`
     /// - Parameter request: The request as a `URLRequest`
     /// - Returns: Type erased publisher with output as `Data` and `NetworkService`'s error domain for failure
@@ -65,28 +64,28 @@ extension NetworkServiceClient {
 }
 
 #if canImport(Combine)
-extension NetworkServiceClient {
-    /// Start a `URLRequest`
-    /// - Parameter request: The request as a `URLRequest`
-    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
-    public func start<ResponseBody, Decoder>(
-        _ request: URLRequest,
-        with decoder: Decoder
-    ) async -> Result<ResponseBody, Failure>
-        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
-    {
-        await start(request)
-            .decode(with: decoder)
-            .mapToNetworkError()
-    }
+    extension NetworkServiceClient {
+        /// Start a `URLRequest`
+        /// - Parameter request: The request as a `URLRequest`
+        /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+        public func start<ResponseBody, Decoder>(
+            _ request: URLRequest,
+            with decoder: Decoder
+        ) async -> Result<ResponseBody, Failure>
+            where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+        {
+            await start(request)
+                .decode(with: decoder)
+                .mapToNetworkError()
+        }
 
-    /// Start a `URLRequest`
-    /// - Parameter request: The request as a `URLRequest`
-    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
-    public func start<ResponseBody>(_ request: URLRequest) async -> Result<ResponseBody, Failure>
-        where ResponseBody: TopLevelDecodable
-    {
-        await start(request, with: ResponseBody.decoder)
+        /// Start a `URLRequest`
+        /// - Parameter request: The request as a `URLRequest`
+        /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+        public func start<ResponseBody>(_ request: URLRequest) async -> Result<ResponseBody, Failure>
+            where ResponseBody: TopLevelDecodable
+        {
+            await start(request, with: ResponseBody.decoder)
+        }
     }
-}
 #endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
@@ -10,30 +10,6 @@ import Combine
 import Foundation
 
 extension NetworkServiceClient {
-    // MARK: URLRequest
-
-    /// Start a `URLRequest`
-    /// - Parameter request: The request as a `URLRequest`
-    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
-    public func start<ResponseBody, Decoder>(
-        _ request: URLRequest,
-        with decoder: Decoder
-    ) async -> Result<ResponseBody, Failure>
-        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
-    {
-        await start(request)
-            .decode(with: decoder)
-            .mapToNetworkError()
-    }
-
-    /// Start a `URLRequest`
-    /// - Parameter request: The request as a `URLRequest`
-    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
-    public func start<ResponseBody>(_ request: URLRequest) async -> Result<ResponseBody, Failure>
-        where ResponseBody: TopLevelDecodable
-    {
-        await start(request, with: ResponseBody.decoder)
-    }
 
     /// Start a `URLRequest`
     /// - Parameter request: The request as a `URLRequest`
@@ -87,3 +63,30 @@ extension NetworkServiceClient {
         }
     }
 }
+
+#if canImport(Combine)
+extension NetworkServiceClient {
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func start<ResponseBody, Decoder>(
+        _ request: URLRequest,
+        with decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+    {
+        await start(request)
+            .decode(with: decoder)
+            .mapToNetworkError()
+    }
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    public func start<ResponseBody>(_ request: URLRequest) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+    {
+        await start(request, with: ResponseBody.decoder)
+    }
+}
+#endif

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient.swift
@@ -1,0 +1,315 @@
+// NetworkServiceClient.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+/// Dependency injection point for `NetworkService`
+public protocol NetworkServiceClient {
+    /// `NetworkService`'s error domain
+    typealias Failure = NetworkService.Failure
+
+    // MARK: Get Session
+
+    /// - Returns: Configured URLSession
+    func getSession() -> URLSession
+
+    // MARK: DELETE
+
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func delete(
+        _ url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+
+    /// Send a delete request to a `URL`
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder: `TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func delete<ResponseBody, Decoder>(
+        _ url: URL,
+        headers: [HTTPHeader],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+
+    /// Send a delete request to a `URL`
+    /// - Parameters:
+    ///     - url: The destination for the request
+    ///     - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    func delete<ResponseBody>(_ url: URL, headers: [HTTPHeader]) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+
+    // MARK: GET
+
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func get(
+        _ url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+
+    /// Send a get request to a `URL`
+    /// - Parameters:
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func get<ResponseBody, Decoder>(
+        _ url: URL,
+        headers: [HTTPHeader],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+
+    /// Send a get request to a `URL`
+    /// - Parameters:
+    ///     - url: The destination for the request
+    ///     - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    func get<ResponseBody>(_ url: URL, headers: [HTTPHeader]) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+
+    // MARK: POST
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func post(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Encodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder: `TopLevelEncoder` for encoding the request body
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func post<RequestBody, Encoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader],
+        encoder: Encoder
+    ) async -> Result<Data, Failure>
+        where RequestBody: Encodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data
+
+    /// - Parameters:
+    ///   - body: The body of the request as `TopLevelEncodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func post<RequestBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+        where RequestBody: TopLevelEncodable
+
+    /// Send a post request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func post<ResponseBody, Decoder>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    func post<ResponseBody>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+
+    /// Send a post request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `Encodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder:`TopLevelEncoder` for encoding the request body
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func post<RequestBody, ResponseBody, Encoder, Decoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader],
+        encoder: Encoder,
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: Encodable,
+        ResponseBody: Decodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data,
+        Decoder: TopLevelDecoder,
+        Decoder.Input == Data
+
+    /// Send a post request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `TopLevelEncodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    func post<RequestBody, ResponseBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: TopLevelEncodable,
+        ResponseBody: TopLevelDecodable
+
+    // MARK: PUT
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func put(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Encodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder: `TopLevelEncoder` for encoding the request body
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func put<RequestBody, Encoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader],
+        encoder: Encoder
+    ) async -> Result<Data, Failure>
+        where RequestBody: Encodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data
+
+    /// - Parameters:
+    ///   - body: The body of the request as `TopLevelEncodable`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `Data` output and `NetworkService`'s error domain for failure
+    func put<RequestBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<Data, Failure>
+        where RequestBody: TopLevelEncodable
+
+    /// Send a put request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func put<ResponseBody, Decoder>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader],
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+
+    /// - Parameters:
+    ///   - body: The body of the request as `Data`
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with `TopLevelDecodable` output and `NetworkService`'s error domain for failure
+    func put<ResponseBody>(
+        _ body: Data,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+
+    /// Send a put request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `Encodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    ///   - encoder:`TopLevelEncoder` for encoding the request body
+    ///   - decoder:`TopLevelDecoder` for decoding the response body
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func put<RequestBody, ResponseBody, Encoder, Decoder>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader],
+        encoder: Encoder,
+        decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: Encodable,
+        ResponseBody: Decodable,
+        Encoder: TopLevelEncoder,
+        Encoder.Output == Data,
+        Decoder: TopLevelDecoder,
+        Decoder.Input == Data
+
+    /// Send a put request to a `URL`
+    /// - Parameters:
+    ///   - body: The body of the request as a `Encodable` conforming type
+    ///   - url: The destination for the request
+    ///   - headers: HTTP headers for the request
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func put<RequestBody, ResponseBody>(
+        _ body: RequestBody,
+        to url: URL,
+        headers: [HTTPHeader]
+    ) async -> Result<ResponseBody, Failure>
+        where RequestBody: TopLevelEncodable,
+        ResponseBody: TopLevelDecodable
+
+    // MARK: URLRequest
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func start<ResponseBody, Decoder>(
+        _ request: URLRequest,
+        with decoder: Decoder
+    ) async -> Result<ResponseBody, Failure>
+        where ResponseBody: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with decoded output and `NetworkService`'s error domain for failure
+    func start<ResponseBody>(_ request: URLRequest) async -> Result<ResponseBody, Failure>
+        where ResponseBody: TopLevelDecodable
+
+    /// Start a `URLRequest`
+    /// - Parameter request: The request as a `URLRequest`
+    /// - Returns: Type erased publisher with output as `Data` and `NetworkService`'s error domain for failure
+    func start(_ request: URLRequest) async -> Result<Data, Failure>
+}

--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient.swift
@@ -10,6 +10,7 @@ import Combine
 import Foundation
 
 /// Dependency injection point for `NetworkService`
+@available(swift 5.5)
 public protocol NetworkServiceClient {
     /// `NetworkService`'s error domain
     typealias Failure = NetworkService.Failure

--- a/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
@@ -6,7 +6,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-import Combine
 import Foundation
 
 extension Result where Success == (Data, URLResponse), Failure == Error {
@@ -47,6 +46,9 @@ extension Result {
     }
 }
 
+#if canImport(Combine)
+import Combine
+
 extension Result {
     func decode<T: Decodable, Decoder: TopLevelDecoder>(with decoder: Decoder) -> Result<T, Error>
         where Decoder.Input == Success
@@ -63,3 +65,4 @@ extension Result {
         decode(with: T.decoder)
     }
 }
+#endif

--- a/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
@@ -1,4 +1,4 @@
-// Publisher+NetworkService.swift
+// Result+NetworkService.swift
 // NetworkService
 //
 // Copyright © 2022 MFB Technologies, Inc. All rights reserved.
@@ -48,7 +48,9 @@ extension Result {
 }
 
 extension Result {
-    func decode<T: Decodable, Decoder: TopLevelDecoder>(with decoder: Decoder) -> Result<T, Error> where Decoder.Input == Success {
+    func decode<T: Decodable, Decoder: TopLevelDecoder>(with decoder: Decoder) -> Result<T, Error>
+        where Decoder.Input == Success
+    {
         mapError { $0 as Error }
             .flatMap { input in
                 Result<T, Error> {

--- a/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
@@ -1,0 +1,63 @@
+// Publisher+NetworkService.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+extension Result where Success == (Data, URLResponse), Failure == Error {
+    /// Casts and unwraps a `URLSession.DataTaskPublisher.Output` while ensuring the
+    /// response code indicates success.
+    /// - Returns:
+    ///     - `Publishers.TryMap<Self, Data>`
+    public func httpMap() -> Result<Data, NetworkService.Failure> {
+        flatMap { data, response in
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .failure(NetworkService.Failure.urlResponse(response))
+            }
+            guard httpResponse.isSuccessful else {
+                return .failure(NetworkService.Failure.httpResponse(httpResponse))
+            }
+            return .success(data)
+        }
+        .mapError { error in
+            guard let failure = error as? NetworkService.Failure else {
+                return .unknown(error as NSError)
+            }
+            return failure
+        }
+    }
+}
+
+extension Result {
+    /// Convenience method for mapping errors to `NetworkService.Failure`
+    /// - Returns:
+    ///     - `Publishers.MapError<Self, NetworkService.Failure>`
+    public func mapToNetworkError() -> Result<Success, NetworkService.Failure> {
+        mapError { error in
+            guard let failure = error as? NetworkService.Failure else {
+                return NetworkService.Failure.unknown(error as NSError)
+            }
+            return failure
+        }
+    }
+}
+
+extension Result {
+    func decode<T: Decodable, Decoder: TopLevelDecoder>(with decoder: Decoder) -> Result<T, Error> where Decoder.Input == Success {
+        mapError { $0 as Error }
+            .flatMap { input in
+                Result<T, Error> {
+                    try decoder.decode(T.self, from: input)
+                }
+            }
+    }
+
+    func decode<T: TopLevelDecodable>() -> Result<T, Error> where T.AdoptedDecoder.Input == Success {
+        decode(with: T.decoder)
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
@@ -47,22 +47,22 @@ extension Result {
 }
 
 #if canImport(Combine)
-import Combine
+    import Combine
 
-extension Result {
-    func decode<T: Decodable, Decoder: TopLevelDecoder>(with decoder: Decoder) -> Result<T, Error>
-        where Decoder.Input == Success
-    {
-        mapError { $0 as Error }
-            .flatMap { input in
-                Result<T, Error> {
-                    try decoder.decode(T.self, from: input)
+    extension Result {
+        func decode<T: Decodable, Decoder: TopLevelDecoder>(with decoder: Decoder) -> Result<T, Error>
+            where Decoder.Input == Success
+        {
+            mapError { $0 as Error }
+                .flatMap { input in
+                    Result<T, Error> {
+                        try decoder.decode(T.self, from: input)
+                    }
                 }
-            }
-    }
+        }
 
-    func decode<T: TopLevelDecodable>() -> Result<T, Error> where T.AdoptedDecoder.Input == Success {
-        decode(with: T.decoder)
+        func decode<T: TopLevelDecodable>() -> Result<T, Error> where T.AdoptedDecoder.Input == Success {
+            decode(with: T.decoder)
+        }
     }
-}
 #endif

--- a/Sources/NetworkServiceAsyncBeta/TopLevelCodable.swift
+++ b/Sources/NetworkServiceAsyncBeta/TopLevelCodable.swift
@@ -1,0 +1,52 @@
+// TopLevelCodable.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+
+/// Associates a default `TopLevelEncoder` type with a given type
+public protocol TopLevelEncodable: Encodable {
+    associatedtype AdoptedEncoder: TopLevelEncoder where AdoptedEncoder.Output == Data
+    @available(*, unavailable, renamed: "AdoptedEncoder")
+    typealias CustomEncoder = Encoder
+
+    /// The default `TopLevelEncoder` for the conforming type
+    static var encoder: AdoptedEncoder { get }
+}
+
+/// Associates a default `TopLevelDecoder` type with a given type
+public protocol TopLevelDecodable: Decodable {
+    associatedtype AdoptedDecoder: TopLevelDecoder where AdoptedDecoder.Input == Data
+
+    /// The default `TopLevelDecoder` for the conforming type
+    static var decoder: AdoptedDecoder { get }
+}
+
+/// Convenience protocol for conforming to `TopLevelEncodable` and `TopLevelDecodable`
+public protocol TopLevelCodable: TopLevelEncodable,
+    TopLevelDecodable where AdoptedEncoder.Output == AdoptedDecoder.Input {}
+
+extension Array: TopLevelEncodable where Element: TopLevelEncodable {
+    public static var encoder: Element.AdoptedEncoder { Element.encoder }
+}
+
+extension Array: TopLevelDecodable where Element: TopLevelDecodable {
+    public static var decoder: Element.AdoptedDecoder { Element.decoder }
+}
+
+extension Array: TopLevelCodable where Element: TopLevelCodable {}
+
+extension Set: TopLevelEncodable where Element: TopLevelEncodable {
+    public static var encoder: Element.AdoptedEncoder { Element.encoder }
+}
+
+extension Set: TopLevelDecodable where Element: TopLevelDecodable {
+    public static var decoder: Element.AdoptedDecoder { Element.decoder }
+}
+
+extension Set: TopLevelCodable where Element: TopLevelCodable {}

--- a/Sources/NetworkServiceAsyncBeta/TopLevelCodable.swift
+++ b/Sources/NetworkServiceAsyncBeta/TopLevelCodable.swift
@@ -7,49 +7,49 @@
 // LICENSE file in the root directory of this source tree.
 
 #if canImport(Combine)
-import Combine
-import Foundation
+    import Combine
+    import Foundation
 
-/// Associates a default `TopLevelEncoder` type with a given type
-public protocol TopLevelEncodable: Encodable {
-    associatedtype AdoptedEncoder: TopLevelEncoder where AdoptedEncoder.Output == Data
-    @available(*, unavailable, renamed: "AdoptedEncoder")
-    typealias CustomEncoder = Encoder
+    /// Associates a default `TopLevelEncoder` type with a given type
+    public protocol TopLevelEncodable: Encodable {
+        associatedtype AdoptedEncoder: TopLevelEncoder where AdoptedEncoder.Output == Data
+        @available(*, unavailable, renamed: "AdoptedEncoder")
+        typealias CustomEncoder = Encoder
 
-    /// The default `TopLevelEncoder` for the conforming type
-    static var encoder: AdoptedEncoder { get }
-}
+        /// The default `TopLevelEncoder` for the conforming type
+        static var encoder: AdoptedEncoder { get }
+    }
 
-/// Associates a default `TopLevelDecoder` type with a given type
-public protocol TopLevelDecodable: Decodable {
-    associatedtype AdoptedDecoder: TopLevelDecoder where AdoptedDecoder.Input == Data
+    /// Associates a default `TopLevelDecoder` type with a given type
+    public protocol TopLevelDecodable: Decodable {
+        associatedtype AdoptedDecoder: TopLevelDecoder where AdoptedDecoder.Input == Data
 
-    /// The default `TopLevelDecoder` for the conforming type
-    static var decoder: AdoptedDecoder { get }
-}
+        /// The default `TopLevelDecoder` for the conforming type
+        static var decoder: AdoptedDecoder { get }
+    }
 
-/// Convenience protocol for conforming to `TopLevelEncodable` and `TopLevelDecodable`
-public protocol TopLevelCodable: TopLevelEncodable,
-    TopLevelDecodable where AdoptedEncoder.Output == AdoptedDecoder.Input {}
+    /// Convenience protocol for conforming to `TopLevelEncodable` and `TopLevelDecodable`
+    public protocol TopLevelCodable: TopLevelEncodable,
+        TopLevelDecodable where AdoptedEncoder.Output == AdoptedDecoder.Input {}
 
-extension Array: TopLevelEncodable where Element: TopLevelEncodable {
-    public static var encoder: Element.AdoptedEncoder { Element.encoder }
-}
+    extension Array: TopLevelEncodable where Element: TopLevelEncodable {
+        public static var encoder: Element.AdoptedEncoder { Element.encoder }
+    }
 
-extension Array: TopLevelDecodable where Element: TopLevelDecodable {
-    public static var decoder: Element.AdoptedDecoder { Element.decoder }
-}
+    extension Array: TopLevelDecodable where Element: TopLevelDecodable {
+        public static var decoder: Element.AdoptedDecoder { Element.decoder }
+    }
 
-extension Array: TopLevelCodable where Element: TopLevelCodable {}
+    extension Array: TopLevelCodable where Element: TopLevelCodable {}
 
-extension Set: TopLevelEncodable where Element: TopLevelEncodable {
-    public static var encoder: Element.AdoptedEncoder { Element.encoder }
-}
+    extension Set: TopLevelEncodable where Element: TopLevelEncodable {
+        public static var encoder: Element.AdoptedEncoder { Element.encoder }
+    }
 
-extension Set: TopLevelDecodable where Element: TopLevelDecodable {
-    public static var decoder: Element.AdoptedDecoder { Element.decoder }
-}
+    extension Set: TopLevelDecodable where Element: TopLevelDecodable {
+        public static var decoder: Element.AdoptedDecoder { Element.decoder }
+    }
 
-extension Set: TopLevelCodable where Element: TopLevelCodable {}
+    extension Set: TopLevelCodable where Element: TopLevelCodable {}
 
 #endif

--- a/Sources/NetworkServiceAsyncBeta/TopLevelCodable.swift
+++ b/Sources/NetworkServiceAsyncBeta/TopLevelCodable.swift
@@ -6,6 +6,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -50,3 +51,5 @@ extension Set: TopLevelDecodable where Element: TopLevelDecodable {
 }
 
 extension Set: TopLevelCodable where Element: TopLevelCodable {}
+
+#endif

--- a/Sources/NetworkServiceAsyncBeta/URLRequest+HTTPHeader.swift
+++ b/Sources/NetworkServiceAsyncBeta/URLRequest+HTTPHeader.swift
@@ -15,6 +15,14 @@ extension URLRequest {
         addValue(header.value, forHTTPHeaderField: header.key)
     }
 
+    /// Add HTTP header values to a URLRequest with type safety, avoiding the use of raw strings
+    /// - Parameter header: The HTTP header to be added
+    public mutating func addValues<S>(_ headers: S) where S: Sequence, S.Element == HTTPHeader {
+        for header in headers {
+            addValue(header)
+        }
+    }
+
     /// Enumeration of all available HTTP ContentTypes
     public enum ContentType: String {
         public static let key = "Content-Type"

--- a/Sources/NetworkServiceAsyncBeta/URLRequest+HTTPHeader.swift
+++ b/Sources/NetworkServiceAsyncBeta/URLRequest+HTTPHeader.swift
@@ -1,0 +1,37 @@
+// URLRequest+HTTPHeader.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+
+extension URLRequest {
+    /// Add HTTP header values to a URLRequest with type safety, avoiding the use of raw strings
+    /// - Parameter header: The HTTP header to be added
+    public mutating func addValue(_ header: HTTPHeader) {
+        addValue(header.value, forHTTPHeaderField: header.key)
+    }
+
+    /// Enumeration of all available HTTP ContentTypes
+    public enum ContentType: String {
+        public static let key = "Content-Type"
+
+        case applicationJSON = "application/json"
+        case textJSON = "text/json"
+        case textPlain = "text/plain"
+    }
+}
+
+extension URLRequest.ContentType: HTTPHeader {
+    public var key: String { Self.key }
+    public var value: String { rawValue }
+}
+
+/// Model for HTTP headers
+public protocol HTTPHeader {
+    var key: String { get }
+    var value: String { get }
+}

--- a/Sources/NetworkServiceAsyncBeta/URLRequest+HTTPMethod.swift
+++ b/Sources/NetworkServiceAsyncBeta/URLRequest+HTTPMethod.swift
@@ -1,0 +1,30 @@
+// URLRequest+HTTPMethod.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+
+extension URLRequest {
+    /// Type-safe enumeration of HTTP methods
+    public enum HTTPMethod: String {
+        case GET, POST, PUT, DELETE
+    }
+
+    /// Getter/Setter wrapper for `httpMethod: String?` using type-safe `HTTPMethod`
+    public var method: HTTPMethod? {
+        get {
+            guard let httpMethod = httpMethod else {
+                return nil
+            }
+            return HTTPMethod(rawValue: httpMethod)
+        }
+
+        set {
+            httpMethod = newValue?.rawValue
+        }
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/URLRequest+Service.swift
+++ b/Sources/NetworkServiceAsyncBeta/URLRequest+Service.swift
@@ -1,14 +1,17 @@
+// URLRequest+Service.swift
+// NetworkService
 //
-//  File.swift
-//  
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
 //
-//  Created by andrew on 9/20/22.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 
 extension URLRequest {
-    static func service<S>(url: URL, body: Data? = nil, headers: S, method: HTTPMethod) -> Self where S: Sequence, S.Element == HTTPHeader {
+    static func service<S>(url: URL, body: Data? = nil, headers: S, method: HTTPMethod) -> Self where S: Sequence,
+        S.Element == HTTPHeader
+    {
         var request = URLRequest(url: url)
         request.httpBody = body
         request.addValues(headers)

--- a/Sources/NetworkServiceAsyncBeta/URLRequest+Service.swift
+++ b/Sources/NetworkServiceAsyncBeta/URLRequest+Service.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by andrew on 9/20/22.
+//
+
+import Foundation
+
+extension URLRequest {
+    static func service<S>(url: URL, body: Data? = nil, headers: S, method: HTTPMethod) -> Self where S: Sequence, S.Element == HTTPHeader {
+        var request = URLRequest(url: url)
+        request.httpBody = body
+        request.addValues(headers)
+        request.method = method
+        return request
+    }
+}

--- a/Sources/NetworkServiceAsyncBeta/URLRequest+build.swift
+++ b/Sources/NetworkServiceAsyncBeta/URLRequest+build.swift
@@ -1,4 +1,4 @@
-// URLRequest+Service.swift
+// URLRequest+build.swift
 // NetworkService
 //
 // Copyright © 2022 MFB Technologies, Inc. All rights reserved.
@@ -9,7 +9,7 @@
 import Foundation
 
 extension URLRequest {
-    static func service<S>(url: URL, body: Data? = nil, headers: S, method: HTTPMethod) -> Self where S: Sequence,
+    static func build<S>(url: URL, body: Data? = nil, headers: S, method: HTTPMethod) -> Self where S: Sequence,
         S.Element == HTTPHeader
     {
         var request = URLRequest(url: url)

--- a/Sources/NetworkServiceTestHelperAsyncBeta/CodableOutput.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/CodableOutput.swift
@@ -1,30 +1,31 @@
+// CodableOutput.swift
+// NetworkService
 //
-//  File.swift
-//  
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
 //
-//  Created by andrew on 9/20/22.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 import NetworkServiceAsyncBeta
 
 #if canImport(Combine)
-import Combine
-/// Fundamental wrapper for output values so they can easily be handled by `MockNetworkService`
-public struct CodableOutput<Output: Codable, Encoder: TopLevelEncoder, Decoder: TopLevelDecoder>: MockOutput
-    where Encoder.Output == Data, Decoder.Input == Data
-{
-    public var output: Result<Data, NetworkService.Failure> {
-        // swiftlint:disable:next force_try
-        .success(try! encoder.encode(value))
-    }
+    import Combine
+    /// Fundamental wrapper for output values so they can easily be handled by `MockNetworkService`
+    public struct CodableOutput<Output: Codable, Encoder: TopLevelEncoder, Decoder: TopLevelDecoder>: MockOutput
+        where Encoder.Output == Data, Decoder.Input == Data
+    {
+        public var output: Result<Data, NetworkService.Failure> {
+            // swiftlint:disable:next force_try
+            .success(try! encoder.encode(value))
+        }
 
-    let value: Output
-    let encoder: Encoder
+        let value: Output
+        let encoder: Encoder
 
-    public init(_ value: Output, encoder: Encoder) {
-        self.value = value
-        self.encoder = encoder
+        public init(_ value: Output, encoder: Encoder) {
+            self.value = value
+            self.encoder = encoder
+        }
     }
-}
 #endif

--- a/Sources/NetworkServiceTestHelperAsyncBeta/CodableOutput.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/CodableOutput.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  
+//
+//  Created by andrew on 9/20/22.
+//
+
+import Foundation
+import NetworkServiceAsyncBeta
+
+#if canImport(Combine)
+import Combine
+/// Fundamental wrapper for output values so they can easily be handled by `MockNetworkService`
+public struct CodableOutput<Output: Codable, Encoder: TopLevelEncoder, Decoder: TopLevelDecoder>: MockOutput
+    where Encoder.Output == Data, Decoder.Input == Data
+{
+    public var output: Result<Data, NetworkService.Failure> {
+        // swiftlint:disable:next force_try
+        .success(try! encoder.encode(value))
+    }
+
+    let value: Output
+    let encoder: Encoder
+
+    public init(_ value: Output, encoder: Encoder) {
+        self.value = value
+        self.encoder = encoder
+    }
+}
+#endif

--- a/Sources/NetworkServiceTestHelperAsyncBeta/Delay.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/Delay.swift
@@ -1,9 +1,10 @@
+// Delay.swift
+// NetworkService
 //
-//  File.swift
-//  
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
 //
-//  Created by andrew on 9/20/22.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 

--- a/Sources/NetworkServiceTestHelperAsyncBeta/Delay.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/Delay.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//  
+//
+//  Created by andrew on 9/20/22.
+//
+
+import Foundation
+
+/// Represents the amount of async delay should be added to the mocked network functions. Consider replacing with `DispatchTimeInterval`.
+/// Although, there is no included case for zero/none.
+public enum Delay {
+    case infinite
+    case seconds(Int)
+    case none
+
+    /// The delay in `DispatchTimeInterval` for use in schedulars
+    var interval: Int {
+        switch self {
+        case .infinite:
+            return .max
+        case let .seconds(seconds):
+            return seconds
+        case .none:
+            return 0
+        }
+    }
+}

--- a/Sources/NetworkServiceTestHelperAsyncBeta/FailureOutput.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/FailureOutput.swift
@@ -1,9 +1,10 @@
+// FailureOutput.swift
+// NetworkService
 //
-//  File.swift
-//  
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
 //
-//  Created by andrew on 9/20/22.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 import NetworkServiceAsyncBeta

--- a/Sources/NetworkServiceTestHelperAsyncBeta/FailureOutput.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/FailureOutput.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//  
+//
+//  Created by andrew on 9/20/22.
+//
+
+import Foundation
+import NetworkServiceAsyncBeta
+
+/// Wraps a provided error for use as output
+public struct FailureOutput<T>: MockOutput where T: Error {
+    public var output: Result<Data, NetworkService.Failure> {
+        if let networkFailure = error as? NetworkService.Failure {
+            return .failure(networkFailure)
+        }
+        return .failure(.unknown(error as NSError))
+    }
+
+    public let error: T
+
+    public init(error: T) {
+        self.error = error
+    }
+}

--- a/Sources/NetworkServiceTestHelperAsyncBeta/MockNetworkService.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/MockNetworkService.swift
@@ -1,0 +1,173 @@
+// MockNetworkService.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import CombineSchedulers
+import Foundation
+import NetworkServiceAsyncBeta
+
+/// Convenience implementation of `NetworkServiceClient` for testing. Supports defining set output values for all network functions,
+/// repeating values, and delaying values.
+open class MockNetworkService<T: Scheduler>: NetworkServiceClient {
+    public var delay: Delay
+    public var outputs: [MockOutput]
+    var nextOutput: MockOutput?
+    let scheduler: T
+
+    public init(outputs: [MockOutput] = [], delay: Delay = .none, scheduler: T) {
+        self.outputs = outputs
+        self.delay = delay
+        self.scheduler = scheduler
+    }
+
+    /// Manages the output queue and returns the new value for reach iteration.
+    private func queue() throws -> MockOutput {
+        guard outputs.count > 0 else {
+            throw Errors.noOutputQueued
+        }
+        let next = outputs.removeFirst()
+        if let repeated = next as? RepeatResponse {
+            switch repeated {
+            case let .repeat(value, count: count):
+                if count > 1 {
+                    outputs.insert(RepeatResponse.repeat(value, count: count - 1), at: 0)
+                }
+            case .repeatInfinite:
+                outputs.insert(repeated, at: 0)
+            }
+        }
+        return next
+    }
+
+    /// Replaces default implementation from protocol. All `NetworkService` functions should eventually end up in this version of `start`.
+    /// Delay and repeat are handled here.
+    public func start(_: URLRequest) async -> Result<Data, Failure> {
+        let next: MockOutput
+        do {
+            next = try queue()
+        } catch {
+            return .failure(Failure.unknown(error as NSError))
+        }
+        switch delay {
+        case .infinite:
+            return await Task {
+                // Using UInt64.max or close to it provides no delay.
+                // One order of magnitude lower and it works as expected.
+                try await Task.sleep(nanoseconds: 10_000_000_000_000_000)
+                return try next.output.get()
+            }
+            .result.mapToNetworkError()
+        case .seconds:
+            return await Task {
+                try await Task.sleep(nanoseconds: UInt64(delay.interval) * 1_000_000_000)
+                return try next.output.get()
+            }
+            .result.mapToNetworkError()
+        case .none:
+            // Setting the delay publisher to zero seconds was buggy.
+            // It works better to not add delay for `none`.
+            return next.output
+        }
+    }
+
+    public enum Errors: Error, Equatable {
+        case noOutputQueued
+    }
+}
+
+/// Represents the amount of async delay should be added to the mocked network functions. Consider replacing with `DispatchTimeInterval`.
+/// Although, there is no included case for zero/none.
+public enum Delay {
+    case infinite
+    case seconds(Int)
+    case none
+
+    /// The delay in `DispatchTimeInterval` for use in schedulars
+    var interval: Int {
+        switch self {
+        case .infinite:
+            return .max
+        case let .seconds(seconds):
+            return seconds
+        case .none:
+            return 0
+        }
+    }
+}
+
+/// Wraps a given output value to define how many times it should be repeated.
+public enum RepeatResponse: MockOutput {
+    case `repeat`(MockOutput, count: Int)
+    case repeatInfinite(MockOutput)
+
+    public var output: Result<Data, NetworkService.Failure> {
+        switch self {
+        case .repeat(let output, count: _), let .repeatInfinite(output):
+            return output.output
+        }
+    }
+}
+
+/// Wraps a provided error for use as output
+public struct FailureOutput<T>: MockOutput where T: Error {
+    public var output: Result<Data, NetworkService.Failure> {
+        if let networkFailure = error as? NetworkService.Failure {
+            return .failure(networkFailure)
+        }
+        return .failure(.unknown(error as NSError))
+    }
+
+    public let error: T
+
+    public init(error: T) {
+        self.error = error
+    }
+}
+
+/// Fundamental wrapper for output values so they can easily be handled by `MockNetworkService`
+public struct CodableOutput<Output: Codable, Encoder: TopLevelEncoder, Decoder: TopLevelDecoder>: MockOutput
+    where Encoder.Output == Data, Decoder.Input == Data
+{
+    public var output: Result<Data, NetworkService.Failure> {
+        // swiftlint:disable:next force_try
+        .success(try! encoder.encode(value))
+    }
+
+    let value: Output
+    let encoder: Encoder
+
+    public init(_ value: Output, encoder: Encoder) {
+        self.value = value
+        self.encoder = encoder
+    }
+}
+
+/// A type erasing protocol for `MockNetworkService`'s output queue. Allows a heterogenous array.
+public protocol MockOutput {
+    var output: Result<Data, NetworkService.Failure> { get }
+}
+
+extension MockOutput where Self: TopLevelEncodable {
+    public var output: Result<Data, NetworkService.Failure> {
+        // swiftlint:disable:next force_try
+        let data = try! Self.encoder.encode(self)
+        return .success(data)
+    }
+}
+
+extension Data: MockOutput {
+    public var output: Result<Data, NetworkService.Failure> {
+        .success(self)
+    }
+}
+
+extension NetworkService.Failure: MockOutput {
+    public var output: Result<Data, Self> {
+        .failure(self)
+    }
+}

--- a/Sources/NetworkServiceTestHelperAsyncBeta/MockNetworkService.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/MockNetworkService.swift
@@ -56,15 +56,13 @@ open class MockNetworkService<T: Scheduler>: NetworkServiceClient {
         switch delay {
         case .infinite:
             return await Task {
-                // Using UInt64.max or close to it provides no delay.
-                // One order of magnitude lower and it works as expected.
-                try await Task.sleep(nanoseconds: 10_000_000_000_000_000)
+                try await scheduler.sleep(for: .seconds(.max))
                 return try next.output.get()
             }
             .result.mapToNetworkError()
         case .seconds:
             return await Task {
-                try await Task.sleep(nanoseconds: UInt64(delay.interval) * 1_000_000_000)
+                try await scheduler.sleep(for: .seconds(delay.interval))
                 return try next.output.get()
             }
             .result.mapToNetworkError()

--- a/Sources/NetworkServiceTestHelperAsyncBeta/MockOutput.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/MockOutput.swift
@@ -1,9 +1,10 @@
+// MockOutput.swift
+// NetworkService
 //
-//  File.swift
-//  
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
 //
-//  Created by andrew on 9/20/22.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 import NetworkServiceAsyncBeta
@@ -26,11 +27,11 @@ extension NetworkService.Failure: MockOutput {
 }
 
 #if canImport(Combine)
-extension MockOutput where Self: TopLevelEncodable {
-    public var output: Result<Data, NetworkService.Failure> {
-        // swiftlint:disable:next force_try
-        let data = try! Self.encoder.encode(self)
-        return .success(data)
+    extension MockOutput where Self: TopLevelEncodable {
+        public var output: Result<Data, NetworkService.Failure> {
+            // swiftlint:disable:next force_try
+            let data = try! Self.encoder.encode(self)
+            return .success(data)
+        }
     }
-}
 #endif

--- a/Sources/NetworkServiceTestHelperAsyncBeta/MockOutput.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/MockOutput.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by andrew on 9/20/22.
+//
+
+import Foundation
+import NetworkServiceAsyncBeta
+
+/// A type erasing protocol for `MockNetworkService`'s output queue. Allows a heterogenous array.
+public protocol MockOutput {
+    var output: Result<Data, NetworkService.Failure> { get }
+}
+
+extension Data: MockOutput {
+    public var output: Result<Data, NetworkService.Failure> {
+        .success(self)
+    }
+}
+
+extension NetworkService.Failure: MockOutput {
+    public var output: Result<Data, Self> {
+        .failure(self)
+    }
+}
+
+#if canImport(Combine)
+extension MockOutput where Self: TopLevelEncodable {
+    public var output: Result<Data, NetworkService.Failure> {
+        // swiftlint:disable:next force_try
+        let data = try! Self.encoder.encode(self)
+        return .success(data)
+    }
+}
+#endif

--- a/Sources/NetworkServiceTestHelperAsyncBeta/RepeatResponse.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/RepeatResponse.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by andrew on 9/20/22.
+//
+
+import Foundation
+import NetworkServiceAsyncBeta
+
+/// Wraps a given output value to define how many times it should be repeated.
+public enum RepeatResponse: MockOutput {
+    case `repeat`(MockOutput, count: Int)
+    case repeatInfinite(MockOutput)
+
+    public var output: Result<Data, NetworkService.Failure> {
+        switch self {
+        case .repeat(let output, count: _), let .repeatInfinite(output):
+            return output.output
+        }
+    }
+}

--- a/Sources/NetworkServiceTestHelperAsyncBeta/RepeatResponse.swift
+++ b/Sources/NetworkServiceTestHelperAsyncBeta/RepeatResponse.swift
@@ -1,9 +1,10 @@
+// RepeatResponse.swift
+// NetworkService
 //
-//  File.swift
-//  
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
 //
-//  Created by andrew on 9/20/22.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 import NetworkServiceAsyncBeta

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Delete.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Delete.swift
@@ -1,0 +1,55 @@
+// NetworkServiceTests+Delete.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import NetworkServiceAsyncBeta
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+extension NetworkServiceTests {
+    // MARK: Success
+
+    func testDeleteSuccess() async throws {
+        let url = try destinationURL()
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(condition: isHost(host) && isPath(path) && isMethodDELETE()) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.ok),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let result: Result<Lyric, Failure> = await service.delete(url)
+        XCTAssertEqual(try result.get(), Lyric.test)
+    }
+
+    // MARK: Failure
+
+    func testDeleteFailure() async throws {
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(condition: isHost(host) && isPath(path) && isMethodDELETE()) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.badRequest),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let url = try destinationURL()
+        let result: Result<Lyric, Failure> = await service.delete(url)
+        guard case let .failure(.httpResponse(response)) = result else {
+            return XCTFail()
+        }
+        XCTAssert(response.isClientError)
+    }
+}

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Get.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Get.swift
@@ -1,0 +1,55 @@
+// NetworkServiceTests+Get.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import NetworkServiceAsyncBeta
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+extension NetworkServiceTests {
+    // MARK: Success
+
+    func testGetSuccess() async throws {
+        let url = try destinationURL()
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(condition: isHost(host) && isPath(path) && isMethodGET()) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.ok),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let result: Result<Lyric, Failure> = await service.get(url)
+        XCTAssertEqual(try result.get(), Lyric.test)
+    }
+
+    // MARK: Failure
+
+    func testGetFailure() async throws {
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(condition: isHost(host) && isPath(path) && isMethodGET()) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.badRequest),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let url = try destinationURL()
+        let result: Result<Lyric, Failure> = await service.get(url)
+        guard case let .failure(.httpResponse(response)) = result else {
+            return XCTFail()
+        }
+        XCTAssert(response.isClientError)
+    }
+}

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Post.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Post.swift
@@ -1,0 +1,65 @@
+// NetworkServiceTests+Post.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import NetworkServiceAsyncBeta
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+extension NetworkServiceTests {
+    // MARK: Success
+
+    func testPostSuccess() async throws {
+        let url = try destinationURL()
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(
+            condition: isHost(host)
+                && isPath(path)
+                && isMethodPOST()
+                && hasBody(data)
+        ) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.ok),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let result: Result<Lyric, Failure> = await service.post(data, to: url)
+        XCTAssertEqual(try result.get(), Lyric.test)
+    }
+
+    // MARK: Failure
+
+    func testPostFailure() async throws {
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(
+            condition: isHost(host)
+                && isPath(path)
+                && isMethodPOST()
+                && hasBody(data)
+        ) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.badRequest),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let url = try destinationURL()
+        let result: Result<Lyric, Failure> = await service.post(data, to: url)
+        guard case let .failure(.httpResponse(response)) = result else {
+            return XCTFail()
+        }
+        XCTAssert(response.isClientError)
+    }
+}

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Put.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests+Put.swift
@@ -1,0 +1,65 @@
+// NetworkServiceTests+Put.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import NetworkServiceAsyncBeta
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+extension NetworkServiceTests {
+    // MARK: Success
+
+    func testPutSuccess() async throws {
+        let url = try destinationURL()
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(
+            condition: isHost(host)
+                && isPath(path)
+                && isMethodPUT()
+                && hasBody(data)
+        ) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.ok),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let result: Result<Lyric, Failure> = await service.put(data, to: url)
+        XCTAssertEqual(try result.get(), Lyric.test)
+    }
+
+    // MARK: Failure
+
+    func testPutFailure() async throws {
+        let data = (try? responseBodyEncoded()) ?? Data()
+        stub(
+            condition: isHost(host)
+                && isPath(path)
+                && isMethodPUT()
+                && hasBody(data)
+        ) { _ in
+            HTTPStubsResponse(
+                data: data,
+                statusCode: Int32(HTTPURLResponse.StatusCode.badRequest),
+                headers: [URLRequest.ContentType.key: URLRequest.ContentType.applicationJSON.value]
+            )
+        }
+
+        let service = NetworkService()
+        let url = try destinationURL()
+        let result: Result<Lyric, Failure> = await service.put(data, to: url)
+        guard case let .failure(.httpResponse(response)) = result else {
+            return XCTFail()
+        }
+        XCTAssert(response.isClientError)
+    }
+}

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests.swift
@@ -1,0 +1,57 @@
+// NetworkServiceTests.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import NetworkServiceAsyncBeta
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+final class NetworkServiceTests: NetworkTestCase {
+    typealias Failure = NetworkService.Failure
+
+    struct Lyric: TopLevelCodable, Equatable {
+        static var encoder: JSONEncoder { JSONEncoder() }
+        static var decoder: JSONDecoder { JSONDecoder() }
+
+        let content: [String]
+
+        static let test = Lyric(content: [
+            "Never gonna give you up",
+            "Never gonna let you down",
+            "Never gonna run around and desert you",
+            "Never gonna make you cry",
+            "Never gonna say goodbye",
+            "Never gonna tell a lie and hurt you",
+        ])
+    }
+
+    func responseBodyEncoded() throws -> Data {
+        try JSONEncoder().encode(Lyric.test)
+    }
+
+    let prefix = "http://"
+    let host = "rick.astley.com"
+    let path = "/never/gonna/give/you/up"
+
+    func destinationURL() throws -> URL {
+        try XCTUnwrap(URL(string: path, relativeTo: URL(string: prefix + host)))
+    }
+
+    static var allTests = [
+        ("testDeleteSuccess", testDeleteSuccess),
+        ("testDeleteFailure", testDeleteFailure),
+        ("testGetSuccess", testGetSuccess),
+        ("testGetFailure", testGetFailure),
+        ("testPostSuccess", testPostSuccess),
+        ("testPostFailure", testPostFailure),
+        ("testPutSuccess", testPutSuccess),
+        ("testPutFailure", testPutFailure),
+    ]
+}

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkServiceTests.swift
@@ -13,6 +13,7 @@ import OHHTTPStubs
 import OHHTTPStubsSwift
 import XCTest
 
+@available(swift 5.5)
 final class NetworkServiceTests: NetworkTestCase {
     typealias Failure = NetworkService.Failure
 

--- a/Tests/NetworkServiceAsyncBetaTests/NetworkTestCase.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/NetworkTestCase.swift
@@ -1,0 +1,18 @@
+// NetworkTestCase.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import OHHTTPStubs
+import XCTest
+
+class NetworkTestCase: XCTestCase {
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+    }
+}

--- a/Tests/NetworkServiceAsyncBetaTests/Result+NetworkServiceTests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/Result+NetworkServiceTests.swift
@@ -11,6 +11,7 @@ import Foundation
 import NetworkServiceAsyncBeta
 import XCTest
 
+@available(swift 5.5)
 final class ResultNetworkServiceTests: XCTestCase {
     // MARK: Publisher where Output == URLSession.DataTaskPublisher.Output
 

--- a/Tests/NetworkServiceAsyncBetaTests/Result+NetworkServiceTests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/Result+NetworkServiceTests.swift
@@ -1,0 +1,99 @@
+// Publisher+NetworkServiceTests.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import Foundation
+import NetworkServiceAsyncBeta
+import XCTest
+
+final class ResultNetworkServiceTests: XCTestCase {
+    // MARK: Publisher where Output == URLSession.DataTaskPublisher.Output
+
+    func testInvalidInput() async throws {
+        let url = try XCTUnwrap(URL(string: "test.com"))
+        let response = URLResponse(
+            url: url,
+            mimeType: "",
+            expectedContentLength: 0,
+            textEncodingName: nil
+        )
+        let input = (Data(), response)
+        let result = Result<(Data, URLResponse), Error>.success(input)
+            .httpMap()
+        guard case let .failure(error) = result else {
+            return XCTFail()
+        }
+        XCTAssertEqual(error, NetworkService.Failure.urlResponse(response))
+    }
+
+    func testUnsuccessfulInput() async throws {
+        let url = try XCTUnwrap(URL(string: "test.com"))
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: HTTPURLResponse.StatusCode.badRequest,
+            httpVersion: "2.0",
+            headerFields: nil
+        ))
+        let input = (Data(), response)
+        let result = Result<(Data, URLResponse), Error>.success(input)
+            .httpMap()
+        guard case let .failure(error) = result else {
+            return XCTFail()
+        }
+        XCTAssertEqual(error, NetworkService.Failure.httpResponse(response))
+    }
+
+    func testSuccessfulInput() async throws {
+        let url = try XCTUnwrap(URL(string: "test.com"))
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: HTTPURLResponse.StatusCode.ok,
+            httpVersion: "2.0",
+            headerFields: nil
+        ))
+        let input = (Data(), response)
+        let result = Result<(Data, URLResponse), Error>.success(input)
+            .httpMap()
+        XCTAssertEqual(try result.get(), input.0)
+    }
+
+    // MARK: Publisher where Failure: Error, Failure == NetworkService.Failure
+
+    func testUnknownNSError() async throws {
+        let result = Result<(Data, URLResponse), Error>.failure(NetworkService.Failure.urlError(URLError(.badServerResponse)))
+            .httpMap()
+        guard case let .failure(error) = result else {
+            return XCTFail()
+        }
+        XCTAssertEqual(error, NetworkService.Failure.urlError(URLError(.badServerResponse)))
+    }
+
+    func testNetworkServiceFailure() async throws {
+        let url = try XCTUnwrap(URL(string: "test.com"))
+        let response = URLResponse(
+            url: url,
+            mimeType: "",
+            expectedContentLength: 0,
+            textEncodingName: nil
+        )
+        let result = Result<(Data, URLResponse), Error>.failure(NetworkService.Failure.urlResponse(response))
+            .httpMap()
+        guard case let .failure(error) = result else {
+            return XCTFail()
+        }
+        XCTAssertEqual(error, NetworkService.Failure.urlResponse(response))
+    }
+
+    static var allTests = [
+        ("testInvalidInput", testInvalidInput),
+        ("testUnsuccessfulInput", testUnsuccessfulInput),
+        ("testSuccessfulInput", testSuccessfulInput),
+        ("testUnknownNSError", testUnknownNSError),
+        ("testNetworkServiceFailure", testNetworkServiceFailure),
+    ]
+}

--- a/Tests/NetworkServiceAsyncBetaTests/Result+NetworkServiceTests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/Result+NetworkServiceTests.swift
@@ -1,4 +1,4 @@
-// Publisher+NetworkServiceTests.swift
+// Result+NetworkServiceTests.swift
 // NetworkService
 //
 // Copyright © 2022 MFB Technologies, Inc. All rights reserved.
@@ -65,7 +65,8 @@ final class ResultNetworkServiceTests: XCTestCase {
     // MARK: Publisher where Failure: Error, Failure == NetworkService.Failure
 
     func testUnknownNSError() async throws {
-        let result = Result<(Data, URLResponse), Error>.failure(NetworkService.Failure.urlError(URLError(.badServerResponse)))
+        let result = Result<(Data, URLResponse), Error>
+            .failure(NetworkService.Failure.urlError(URLError(.badServerResponse)))
             .httpMap()
         guard case let .failure(error) = result else {
             return XCTFail()

--- a/Tests/NetworkServiceAsyncBetaTests/XCTestManifests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/XCTestManifests.swift
@@ -1,0 +1,18 @@
+// XCTestManifests.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import XCTest
+
+#if !canImport(ObjectiveC)
+    public func allTests() -> [XCTestCaseEntry] {
+        [
+            testCase(NetworkServiceTests.allTests),
+            testCase(PublisherNetworkServicesTests.allTests),
+        ]
+    }
+#endif

--- a/Tests/NetworkServiceAsyncBetaTests/XCTestManifests.swift
+++ b/Tests/NetworkServiceAsyncBetaTests/XCTestManifests.swift
@@ -9,6 +9,7 @@
 import XCTest
 
 #if !canImport(ObjectiveC)
+    @available(swift 5.5)
     public func allTests() -> [XCTestCaseEntry] {
         [
             testCase(NetworkServiceTests.allTests),

--- a/Tests/NetworkServiceTestHelperAsyncBetaTests/MockNetworkServiceTests.swift
+++ b/Tests/NetworkServiceTestHelperAsyncBetaTests/MockNetworkServiceTests.swift
@@ -1,0 +1,98 @@
+// MockNetworkServiceTests.swift
+// NetworkService
+//
+// Copyright © 2022 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+import Combine
+import CombineSchedulers
+import Foundation
+import NetworkServiceAsyncBeta
+import NetworkServiceTestHelperAsyncBeta
+import XCTest
+
+struct MockingBird: TopLevelCodable, MockOutput, Equatable {
+    var output: Result<Data, NetworkService.Failure> {
+        // swiftlint:disable:next force_try
+        .success(try! Self.encoder.encode(self))
+    }
+
+    let chirp: Bool
+
+    static let encoder = JSONEncoder()
+    static let decoder = JSONDecoder()
+
+    static let chirp: Self = MockingBird(chirp: true)
+    static let notChirp: Self = MockingBird(chirp: false)
+}
+
+func url() throws -> URL {
+    try XCTUnwrap(URL(string: "/"))
+}
+
+final class NetworkServiceTestHelper: XCTestCase {
+    typealias Failure = MockNetworkService<AnySchedulerOf<DispatchQueue>>.Failure
+
+    var cancellables = [AnyCancellable]()
+    let scheduler: AnySchedulerOf<DispatchQueue> = DispatchQueue.global(qos: .userInteractive).eraseToAnyScheduler()
+
+    override func tearDown() {
+        cancellables.forEach { $0.cancel() }
+    }
+
+    func testQueueInfiniteRepeat() async throws {
+        let mock = MockNetworkService(scheduler: scheduler)
+        mock.outputs = [RepeatResponse.repeatInfinite(MockingBird.chirp)]
+        for _ in 0 ..< 5 {
+            let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+            XCTAssertEqual(try result.get(), .chirp)
+        }
+        let queuedOutput = try XCTUnwrap(mock.outputs.first as? RepeatResponse)
+        switch queuedOutput {
+        case .repeat:
+            XCTFail("Queued output is wrong value")
+        case let .repeatInfinite(output):
+            XCTAssertEqual(output as? MockingBird, MockingBird.chirp, "Queued output matches expectation")
+        }
+    }
+
+    func testQueueFiniteRepeat() async throws {
+        let mock = MockNetworkService(scheduler: scheduler)
+        mock.outputs = [RepeatResponse.repeat(MockingBird(chirp: true), count: 5)]
+        for _ in 0 ..< 5 {
+            let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+            XCTAssertEqual(try result.get(), .chirp)
+        }
+        XCTAssert(mock.outputs.isEmpty, "Output queue is empty after the specified number of repititions")
+    }
+
+    func testFiniteDelay() async throws {
+        let mock = MockNetworkService(scheduler: scheduler)
+        mock.delay = Delay.seconds(2)
+        mock.outputs = [MockingBird.chirp]
+        let startTime = Date()
+        let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+        let endTime = Date()
+        let duration = startTime.distance(to: endTime)
+        XCTAssertGreaterThan(duration, 2)
+        XCTAssertLessThan(duration, 3)
+        XCTAssertEqual(try result.get(), MockingBird.chirp)
+    }
+
+    func testInfiniteDelay() async throws {
+        let mock = MockNetworkService(scheduler: scheduler)
+        mock.delay = Delay.infinite
+        mock.outputs = [MockingBird.chirp]
+        let expectation = expectation(description: "Never receive a response")
+        expectation.isInverted = true
+        let task = Task {
+            let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+            XCTAssertEqual(try result.get(), MockingBird.chirp)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+        task.cancel()
+    }
+}

--- a/Tests/NetworkServiceTestHelperAsyncBetaTests/MockNetworkServiceTests.swift
+++ b/Tests/NetworkServiceTestHelperAsyncBetaTests/MockNetworkServiceTests.swift
@@ -32,6 +32,7 @@ func url() throws -> URL {
     try XCTUnwrap(URL(string: "/"))
 }
 
+@available(swift 5.5)
 final class NetworkServiceTestHelper: XCTestCase {
     typealias Failure = MockNetworkService<AnySchedulerOf<DispatchQueue>>.Failure
 


### PR DESCRIPTION
Add standalone targets that upgrade all code to use async/await instead of Combine. A future PR/release will remove the old Combine based targets and make the async/await targets main.