### PR TITLE
Feature/improve mapping of errors

### DIFF
--- a/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
+++ b/Sources/NetworkServiceAsyncBeta/NetworkServiceClient+Start.swift
@@ -23,7 +23,6 @@ extension NetworkServiceClient {
         }
         return result
             .httpMap()
-            .mapToNetworkError()
     }
 
     private func response(_ request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
+++ b/Sources/NetworkServiceAsyncBeta/Result+NetworkService.swift
@@ -23,12 +23,7 @@ extension Result where Success == (Data, URLResponse), Failure == Error {
             }
             return .success(data)
         }
-        .mapError { error in
-            guard let failure = error as? NetworkService.Failure else {
-                return .unknown(error as NSError)
-            }
-            return failure
-        }
+        .mapToNetworkError()
     }
 }
 
@@ -38,10 +33,13 @@ extension Result {
     ///     - `Publishers.MapError<Self, NetworkService.Failure>`
     public func mapToNetworkError() -> Result<Success, NetworkService.Failure> {
         mapError { error in
-            guard let failure = error as? NetworkService.Failure else {
-                return NetworkService.Failure.unknown(error as NSError)
+            if let urlError = error as? URLError {
+                return .urlError(urlError)
+            } else if let failure = error as? NetworkService.Failure {
+                return failure
+            } else {
+                return .unknown(error as NSError)
             }
-            return failure
         }
     }
 }

--- a/Tests/NetworkServiceTestHelperAsyncBetaTests/MockNetworkServiceTests.swift
+++ b/Tests/NetworkServiceTestHelperAsyncBetaTests/MockNetworkServiceTests.swift
@@ -42,7 +42,7 @@ final class NetworkServiceTestHelper: XCTestCase {
         let mock = MockNetworkService(scheduler: scheduler)
         mock.outputs = [RepeatResponse.repeatInfinite(MockingBird.chirp)]
         for _ in 0 ..< 5 {
-            let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+            let result: Result<MockingBird, NetworkService.Failure> = try await mock.get(url())
             XCTAssertEqual(try result.get(), .chirp)
         }
         let queuedOutput = try XCTUnwrap(mock.outputs.first as? RepeatResponse)
@@ -58,7 +58,7 @@ final class NetworkServiceTestHelper: XCTestCase {
         let mock = MockNetworkService(scheduler: scheduler)
         mock.outputs = [RepeatResponse.repeat(MockingBird(chirp: true), count: 5)]
         for _ in 0 ..< 5 {
-            let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+            let result: Result<MockingBird, NetworkService.Failure> = try await mock.get(url())
             XCTAssertEqual(try result.get(), .chirp)
         }
         XCTAssert(mock.outputs.isEmpty, "Output queue is empty after the specified number of repititions")
@@ -69,7 +69,7 @@ final class NetworkServiceTestHelper: XCTestCase {
         mock.delay = Delay.seconds(2)
         mock.outputs = [MockingBird.chirp]
         let startTime = Date()
-        let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+        let result: Result<MockingBird, NetworkService.Failure> = try await mock.get(url())
         let endTime = Date()
         let duration = startTime.distance(to: endTime)
         XCTAssertGreaterThan(duration, 2)
@@ -84,7 +84,7 @@ final class NetworkServiceTestHelper: XCTestCase {
         let expectation = expectation(description: "Never receive a response")
         expectation.isInverted = true
         let task = Task {
-            let result: Result<MockingBird, NetworkService.Failure> = await mock.get(try url())
+            let result: Result<MockingBird, NetworkService.Failure> = try await mock.get(url())
             XCTAssertEqual(try result.get(), MockingBird.chirp)
             expectation.fulfill()
         }


### PR DESCRIPTION
- Try errors as URLError in Result.mapToNetworkError
- Run swiftformat