### PR TITLE
Update combine-schedulers to 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-12
-            xcode: 13.4.1 # Swift 5.6
           - os: macos-13
             xcode: 14.2 # Swift 5.7
           - os: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            xcode: 13.2.1 # Swift 5.5.2
-          - os: macos-12
             xcode: 13.4.1 # Swift 5.6
           - os: macos-13
             xcode: 14.2 # Swift 5.7

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers.git",
         "state": {
           "branch": null,
-          "revision": "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-          "version": "0.9.1"
+          "revision": "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
+          "version": "1.0.0"
         }
       },
       {
@@ -20,12 +20,21 @@
         }
       },
       {
+        "package": "swift-concurrency-extras",
+        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
+        "state": {
+          "branch": null,
+          "revision": "ea631ce892687f5432a833312292b80db238186a",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "xctest-dynamic-overlay",
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "4af50b38daf0037cfbab15514a241224c3f62f98",
-          "version": "0.8.5"
+          "revision": "302891700c7fa3b92ebde9fe7b42933f8349f3c7",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ extension Package.Dependency {
         .package(
             name: "combine-schedulers",
             url: "https://github.com/pointfreeco/combine-schedulers.git",
-            .upToNextMajor(from: "0.6.0")
+            from: "1.0.0"
         ),
     ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -25,10 +25,7 @@ extension Product {
 
 extension Target {
     static let targets: [Target] = [
-        .target(
-            name: "NetworkService",
-            dependencies: []
-        ),
+        .target(name: "NetworkService"),
         .testTarget(
             name: "NetworkServiceTests",
             dependencies: [
@@ -58,7 +55,6 @@ extension Package.Dependency {
     static let dependencies: [Package.Dependency] = [
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
         .package(
-            name: "combine-schedulers",
             url: "https://github.com/pointfreeco/combine-schedulers.git",
             from: "1.0.0"
         ),


### PR DESCRIPTION
- Update combine-schedulers to 1.0.0
- Bump minimum swift version to 5.6 for swift-concurrency-extras (upstream dependency of combine-schedulers)
- Remove Xcode 13.4.1, Swift 5.6.1 from CI matrix because of buggy behavior on runner