### PR TITLE
Feature/strict concurrency checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             xcode: 14.2 # Swift 5.7
           - os: macos-13
             xcode: 14.3 # Swift 5.8
+          - os: macos-13
+            xcode: '15.0' # Swift 5.9
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,73 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "NetworkService",
+    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
+    products: Product.products,
+    dependencies: Package.Dependency.dependencies,
+    targets: Target.targets
+)
+
+extension Product {
+    static let products: [Product] = [
+        .library(
+            name: "NetworkService",
+            targets: ["NetworkService"]
+        ),
+        .library(
+            name: "NetworkServiceTestHelper",
+            targets: ["NetworkServiceTestHelper"]
+        ),
+    ]
+}
+
+extension Target {
+    static let targets: [Target] = [
+        .target(name: "NetworkService"),
+        .testTarget(
+            name: "NetworkServiceTests",
+            dependencies: [
+                "NetworkService",
+                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+            ]
+        ),
+        .target(
+            name: "NetworkServiceTestHelper",
+            dependencies: [
+                "NetworkService",
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ]
+        ),
+        .testTarget(
+            name: "NetworkServiceTestHelperTests",
+            dependencies: [
+                "NetworkServiceTestHelper",
+                .product(name: "CombineSchedulers", package: "combine-schedulers"),
+            ]
+        ),
+    ]
+}
+
+package.targets.strictConcurrency()
+
+extension Array where Element == Target {
+    func strictConcurrency() {
+        forEach { target in
+            target.swiftSettings = (target.swiftSettings ?? [])
+                + [.enableUpcomingFeature("StrictConcurrency")]
+        }
+    }
+}
+
+extension Package.Dependency {
+    static let dependencies: [Package.Dependency] = [
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+        .package(
+            url: "https://github.com/pointfreeco/combine-schedulers.git",
+            from: "1.0.0"
+        ),
+    ]
+}

--- a/Sources/NetworkService/NetworkService.swift
+++ b/Sources/NetworkService/NetworkService.swift
@@ -10,7 +10,7 @@ import Combine
 import Foundation
 
 /// Provides methods for making network requests and processing the resulting responses
-public final class NetworkService {
+public final class NetworkService: Sendable {
     /// `NetworkService`'s error domain
     public enum Failure: Error, Hashable, Sendable {
         case urlResponse(URLResponse)


### PR DESCRIPTION
- Enable strict concurrency checking for swift 5.8+
- Conform NetworkService to Sendable
- Add Xcode 15/Swift 5.9 test strategy to workflow