### PR TITLE
Fixes for Xcode 16 and Swift 6

### DIFF
--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -5,56 +5,60 @@ import PackageDescription
 let package = Package(
     name: "NetworkService",
     platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
-    products: Product.products,
-    dependencies: Package.Dependency.dependencies,
-    targets: Target.targets
+    products: Product.products(),
+    dependencies: Package.Dependency.dependencies(),
+    targets: Target.targets()
 )
 
 extension Product {
-    static let products: [Product] = [
-        .library(
-            name: "NetworkService",
-            targets: ["NetworkService"]
-        ),
-        .library(
-            name: "NetworkServiceTestHelper",
-            targets: ["NetworkServiceTestHelper"]
-        ),
-    ]
+    static func products() -> [Product] {
+        [
+            .library(
+                name: "NetworkService",
+                targets: ["NetworkService"]
+            ),
+            .library(
+                name: "NetworkServiceTestHelper",
+                targets: ["NetworkServiceTestHelper"]
+            ),
+        ]
+    }
 }
 
 extension Target {
-    static let targets: [Target] = [
-        .target(
-            name: "NetworkService",
-            swiftSettings: .swiftSix
-        ),
-        .testTarget(
-            name: "NetworkServiceTests",
-            dependencies: [
-                "NetworkService",
-                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
-                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
-            ],
-            swiftSettings: .swiftSix
-        ),
-        .target(
-            name: "NetworkServiceTestHelper",
-            dependencies: [
-                "NetworkService",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ],
-            swiftSettings: .swiftSix
-        ),
-        .testTarget(
-            name: "NetworkServiceTestHelperTests",
-            dependencies: [
-                "NetworkServiceTestHelper",
-                .product(name: "CombineSchedulers", package: "combine-schedulers"),
-            ],
-            swiftSettings: .swiftSix
-        ),
-    ]
+    static func targets() -> [Target] {
+        [
+            .target(
+                name: "NetworkService",
+                swiftSettings: .swiftSix
+            ),
+            .testTarget(
+                name: "NetworkServiceTests",
+                dependencies: [
+                    "NetworkService",
+                    .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                    .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+                ],
+                swiftSettings: .swiftSix
+            ),
+            .target(
+                name: "NetworkServiceTestHelper",
+                dependencies: [
+                    "NetworkService",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ],
+                swiftSettings: .swiftSix
+            ),
+            .testTarget(
+                name: "NetworkServiceTestHelperTests",
+                dependencies: [
+                    "NetworkServiceTestHelper",
+                    .product(name: "CombineSchedulers", package: "combine-schedulers"),
+                ],
+                swiftSettings: .swiftSix
+            ),
+        ]
+    }
 }
 
 extension [SwiftSetting] {
@@ -64,21 +68,21 @@ extension [SwiftSetting] {
         .enableUpcomingFeature("DisableOutwardActorInference"),
         .enableUpcomingFeature("ExistentialAny"),
         .enableUpcomingFeature("ForwardTrailingClosures"),
-        .enableUpcomingFeature("FullTypedThrows"),
         .enableUpcomingFeature("ImplicitOpenExistentials"),
         .enableUpcomingFeature("ImportObjcForwardDeclarations"),
-        .enableUpcomingFeature("InternalImportsByDefault"),
         .enableUpcomingFeature("IsolatedDefaultValues"),
-        .enableUpcomingFeature("StrictConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency"),
     ]
 }
 
 extension Package.Dependency {
-    static let dependencies: [Package.Dependency] = [
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-        .package(
-            url: "https://github.com/pointfreeco/combine-schedulers.git",
-            from: "1.0.0"
-        ),
-    ]
+    static func dependencies() -> [Package.Dependency] {
+        [
+            .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+            .package(
+                url: "https://github.com/pointfreeco/combine-schedulers.git",
+                from: "1.0.0"
+            ),
+        ]
+    }
 }

--- a/Sources/NetworkService/NetworkServiceClient+Start.swift
+++ b/Sources/NetworkService/NetworkServiceClient+Start.swift
@@ -55,7 +55,7 @@ extension NetworkServiceClient {
     }
 }
 
-private final class TaskIdBox {
+private final class TaskIdBox: @unchecked Sendable {
     var value: Int?
 
     init(_ value: Int? = nil) {

--- a/Sources/NetworkService/URLRequest+HTTPHeader.swift
+++ b/Sources/NetworkService/URLRequest+HTTPHeader.swift
@@ -49,7 +49,7 @@ extension Array where Element: HTTPHeader {
 }
 
 /// Model for HTTP headers
-public protocol HTTPHeader {
+public protocol HTTPHeader: Sendable {
     var key: String { get }
     var value: String { get }
 }

--- a/Sources/NetworkServiceTestHelper/MockOutput.swift
+++ b/Sources/NetworkServiceTestHelper/MockOutput.swift
@@ -10,7 +10,7 @@ import Foundation
 import NetworkService
 
 /// A type erasing protocol for `MockNetworkService`'s output queue. Allows a heterogenous array.
-public protocol MockOutput {
+public protocol MockOutput: Sendable {
     var output: Result<Data, NetworkService.Failure> { get }
 }
 

--- a/Tests/NetworkServiceTests/NetworkServiceTests.swift
+++ b/Tests/NetworkServiceTests/NetworkServiceTests.swift
@@ -44,16 +44,5 @@
         func destinationURL() throws -> URL {
             try XCTUnwrap(URL(string: path, relativeTo: URL(string: prefix + host)))
         }
-
-        static var allTests = [
-            ("testDeleteSuccess", testDeleteSuccess),
-            ("testDeleteFailure", testDeleteFailure),
-            ("testGetSuccess", testGetSuccess),
-            ("testGetFailure", testGetFailure),
-            ("testPostSuccess", testPostSuccess),
-            ("testPostFailure", testPostFailure),
-            ("testPutSuccess", testPutSuccess),
-            ("testPutFailure", testPutFailure),
-        ]
     }
 #endif

--- a/Tests/NetworkServiceTests/Result+NetworkServiceTests.swift
+++ b/Tests/NetworkServiceTests/Result+NetworkServiceTests.swift
@@ -90,13 +90,5 @@
             }
             XCTAssertEqual(error, NetworkService.Failure.urlResponse(response))
         }
-
-        static var allTests = [
-            ("testInvalidInput", testInvalidInput),
-            ("testUnsuccessfulInput", testUnsuccessfulInput),
-            ("testSuccessfulInput", testSuccessfulInput),
-            ("testUnknownNSError", testUnknownNSError),
-            ("testNetworkServiceFailure", testNetworkServiceFailure),
-        ]
     }
 #endif


### PR DESCRIPTION
- Disable internal imports by default
- Fix StrictConcurrency flag
- Require Sendable conformance on MockOutput and HTTPHeader
- Remove old 'allTests' properties